### PR TITLE
Use STATIC_URL for a few images

### DIFF
--- a/tcms/templates/run/status_statistics.html
+++ b/tcms/templates/run/status_statistics.html
@@ -23,8 +23,8 @@
 	</ul>
 	<div class="clear"></div>
 	<ul>
-		<li style="background:url(../../static/images/btn_bg_report.png) no-repeat; height:25px; line-height:25px; width:57px; padding-left:30px; margin-right:15px;"><a href="{% url "run-report" test_run.run_id %}" title="report of test caserun">Report</a></li>
-		<li style="background:url(../../static/images/btn_bg_showbug.png) no-repeat; height:25px; line-height:25px; width:133px; padding-left:30px;">
+		<li style="background:url({{ STATIC_URL }}images/btn_bg_report.png) no-repeat; height:25px; line-height:25px; width:57px; padding-left:30px; margin-right:15px;"><a href="{% url "run-report" test_run.run_id %}" title="report of test caserun">Report</a></li>
+		<li style="background:url({{ STATIC_URL }}images/btn_bg_showbug.png) no-repeat; height:25px; line-height:25px; width:133px; padding-left:30px;">
 		{% ifnotequal test_case_run_bugs_count 0 %}
 			<span id="total_run_bug_count"><a href="{% url "run-report" test_run.run_id %}#buglist" title="Show All Bugs">Bugs [{{ test_case_run_bugs_count }}]</a></span>
 		{% else %}

--- a/tcms/templates/run/table_caseruns.html
+++ b/tcms/templates/run/table_caseruns.html
@@ -63,7 +63,7 @@
 			<td class="expandable center">
 				<img border="0" alt="" class="icon_status btn_{{ status_name|lower }}" />
 			</td>
-			<td><div id="{{ test_case_run.case_id }}_case_comment_count">{% if comments_count %}<img src="/static/images/comment.png" style="vertical-align: middle;">{%endif %} <span id="{{ test_case_run.case_id }}_comments_count">{{ comments_count }}</span></div></td>
+			<td><div id="{{ test_case_run.case_id }}_case_comment_count">{% if comments_count %}<img src="{{ STATIC_URL }}images/comment.png" style="vertical-align: middle;">{%endif %} <span id="{{ test_case_run.case_id }}_comments_count">{{ comments_count }}</span></div></td>
 			<td class="expandable">
 				<span class="mark">
 					<a href="#" class="js-change-order" data-params='["{{ test_case_run.run_id }}", "{{ test_case_run.pk }}", "{{ test_case_run.sortkey }}"]'>{{ test_case_run.sortkey }}</a>


### PR DESCRIPTION
Also fix comments_count by casting the primary key value to string because the dict structure containing the values uses string keys, not integers.

NOTE: There are quire a few static images assigned dynamically from the JavaScript files or from CSS styles. I can make these work by treating JS and CSS as templates and using the ``STATIC_URL variable``. This is dependent on django-compressor, which in turn needs a recent Django version (see my other PR).