### PR TITLE
using DataTable to show test runs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ odfpy>=0.9.6
 django-pagination==1.0.7
 django-tinymce==1.5.1
 beautifulsoup4>=4.1.1
+six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/tcms/core/utils/__init__.py
+++ b/tcms/core/utils/__init__.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 
+import re
+
+numeric_re = re.compile(r'^\d+$')
+
+
+def is_int(s):
+    return re.match(s) is not None
+
 
 def string_to_list(strs, spliter=','):
     """Convert the string to list"""

--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -13,8 +13,6 @@ Nitrate.TestRuns.List.on_load = function() {
   bind_build_selector_to_product(true, jQ('#id_product')[0]);
 
   Nitrate.Utils.enableShiftSelectOnCheckbox('run_selector');
-  jQ('.btn-statistics').live('click', Nitrate.TestRuns.Progress.percent);
-  jQ('#btn_selected_progress').live('click', Nitrate.TestRuns.Progress.showPercentageOfSelectedRuns);
 
   if (jQ('#testruns_table').length) {
     jQ('#id_check_all_runs').bind('click',function(e) {
@@ -49,7 +47,7 @@ Nitrate.TestRuns.List.on_load = function() {
       "aaSorting": [[ 1, "desc" ]],
       "bProcessing": true,
       "bServerSide": true,
-      "sAjaxSource": "/runs/ajax/"+this.window.location.search,
+      "sAjaxSource": "/runs/ajax/" + this.window.location.search,
       "aoColumns": [
         {"bSortable": false },
         {"sType": "numeric"},
@@ -60,7 +58,7 @@ Nitrate.TestRuns.List.on_load = function() {
         null,
         null,
         null,
-        {"sType": "numeric"},
+        {"sType": "numeric", "bSortable": false},
         null,
         {"bSortable": false }
       ],
@@ -426,52 +424,6 @@ Nitrate.TestRuns.AssignCase.on_load = function() {
   jQ('.js-toggle-button, .js-case-summary').bind('click', function() {
     toggleTestCaseContents(jQ(this).data('param'));
   });
-};
-
-Nitrate.TestRuns.Progress = {
-  /*
-   * This is a run-search page specific
-   * js callback to lazy-load the testrun progress.
-   */
-  'percent': function (e) {
-    var target = jQ(e.target);
-    var tr = target.parent().parent();
-    var url = '/run/' + target.attr('run') + '/percent/';
-    jQ.ajax(url, {
-      dataType: 'json',
-      data: {'status': 'completed_case_run_percent'},
-      beforeSend: function () {
-        target.text('calculating ...');
-      },
-      success: function (data) {
-        var percent = data.percent;
-        tr.find('.percent').html(percent + '%');
-        tr.find('.progress-inner').css({'width': percent});
-      }
-    });
-    jQ.ajax(url, {
-      dataType: 'json',
-      data: {'status': 'failed_case_run_percent'},
-      success: function (data) {
-        var percent = data.percent;
-        tr.find('.progress-failed').css({'width': percent});
-        target.hide();
-        tr.find('.progress-bar').show();
-      }
-    });
-    return false;
-  },
-  'showPercentageOfSelectedRuns': function () {
-    var checkedBoxes = jQ('.run_selector:checked');
-    checkedBoxes.each(function (index, box) {
-      jQ(box).parent().parent().find('.btn-statistics').each(function (index, elem) {
-        var clickable = jQ(elem);
-        if (clickable.css('display') != 'none') {
-          clickable.trigger('click');
-        }
-      });
-    });
-  }
 };
 
 var updateCaseRunStatus = function(e) {

--- a/tcms/templates/plan/common/json_plan_runs.txt
+++ b/tcms/templates/plan/common/json_plan_runs.txt
@@ -1,29 +1,26 @@
 {
-    "sEcho": {{sEcho}},
-    "iTotalRecords": {{iTotalRecords}},
-    "iTotalDisplayRecords": {{iTotalDisplayRecords}},
-    "aaData":[
-    {% for test_run in querySet %}
-    [
-        "<input type='checkbox' name='run' value='{{ test_run.pk }}' class='run_selector'>",
-        "<a href='{% url "tcms.testruns.views.get" test_run.run_id %}' >{{ test_run.run_id }}</a>",
-        "<a href='{% url "tcms.testruns.views.get" test_run.run_id %}' >{{ test_run.summary }}</a>",
-        "<a href='{% url "tcms.profiles.views.profile" test_run.manager.username %}'>{{ test_run.manager }}</a>",
-        {% if test_run.default_tester_id %}
-            "<a href='{% url "tcms.profiles.views.profile" test_run.default_tester.username %}'>{{test_run.default_tester}}</a>"
-        {% else %}
-            "{{test_run.default_tester}}"
-        {% endif %},
-        "{{test_run.start_date}}",
-        "{{test_run.build}}",
-        "{% if test_run.stop_date %}Finished{% else %}Running{% endif %}",
-        "{{test_run.total_num_caseruns}}",
-        "<a href='#statistics' class='btn-statistics' run='{{test_run.run_id}}' status='failed_case_run_percent'>calculate</a><div class='progress-bar' style='width:100px; display:none;'><div class='percent'></div><div class='progress-failed'></div></div>",
-        "<a href='#statistics' class='btn-statistics' run='{{test_run.run_id}}' status='passed_case_run_percent'>calculate</a><div class='progress-bar' style='width:100px; display:none;'><div class='percent'></div><div class='progress-inner'></div></div>"
-        ]
-    {% if not forloop.last %}
-    ,
-    {% endif %}
-    {% endfor %}
-    ]
+	"sEcho": {{sEcho}},
+	"iTotalRecords": {{iTotalRecords}},
+	"iTotalDisplayRecords": {{iTotalDisplayRecords}},
+	"aaData": [
+		{% for run in runs %}
+		[
+			"<input type='checkbox' name='run' value='{{ run.pk }}' class='run_selector'>",
+			"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{ run.run_id }}</a>",
+			"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{ run.summary }}</a>",
+			"<a href='{% url "tcms.profiles.views.profile" run.manager.username %}'>{{ run.manager }}</a>",
+			{% if run.default_tester_id %}
+				"<a href='{% url "tcms.profiles.views.profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
+			{% else %}
+				"{{ run.default_tester }}"
+			{% endif %},
+			"{{ run.start_date }}",
+			"{{ run.build }}",
+			"{% if run.stop_date %}Finished{% else %}Running{% endif %}",
+			"{{ run.nitrate_stats.cases }}",
+			"<div style='width: 100px;' class='progress-bar'><div class='percent'>{{ run.nitrate_stats.failure_percent|floatformat:2 }}%</div><div class='progress-failed' style='width: {{ run.nitrate_stats.failure_percent|floatformat:2 }}px;'></div></div>",
+			"<div style='width: 100px;' class='progress-bar'><div class='percent'>{{ run.nitrate_stats.success_percent|floatformat:2 }}%</div><div class='progress-inner' style='width: {{ run.nitrate_stats.success_percent|floatformat:2 }}px;'></div></div>"
+		]{% if not forloop.last %},{% endif %}
+        {% endfor %}
+	]
 }

--- a/tcms/templates/plan/get_runs.html
+++ b/tcms/templates/plan/get_runs.html
@@ -25,7 +25,7 @@
 			</div>
 			<div class="listinfo">
 				<div class="title"></div>
-				<div class="listinfo_input"><button id="reload_runs">Reload</button></div>
+				<div class="listinfo_input"><button id="reload_runs">Filter</button></div>
 				<input type="hidden" name="page_num" id="js-page-num" value="1"/>
 				<input type="hidden" name="plan" value="{{test_plan.pk}}"/>
 			</div>
@@ -58,38 +58,31 @@
 	<input type="hidden" name="from_plan" value="{{ test_plan.pk }}" />
 	<input type="hidden" name="product" value="{{ test_plan.product.pk }}" />
 	<input type="hidden" name="product_version" value="{{ test_plan.product_version_id }}" />
-	{% if perms.testruns.add_testrun %}
-	<div class="mixbar actions">
-		<div class='marginLeft fixed'>
-			<span id="box_select_rest" style="display:none;" class="tips left_float">
-				<input type="checkbox" name="filter_str"/>
-				Also select all runs not yet shown below
-			</span>
-			<input class="clone icon_plan left_float" type="submit"
-				value="Clone" title="clone selected test runs"/>
-			<input class="progress icon_plan" type="button"
-				value="Calculate progress of selected runs" id="btn_selected_progress"
-				title="calculate progress of selected test runs"/>
-		</div>
-	</div>
-	{% endif %}
+
+ {% if perms.testruns.add_testrun %}
+ <div class="mixbar actions">
+	 <input class="clone icon_plan left_float" type="submit" value="Clone" title="clone selected test runs" />
+ </div>
+ {% endif %}
+
 	<table class="list" id="testruns_table" cellpadding="0" cellspacing="0" border="0" data-param="{{test_plan.pk}}">
 		<thead>
 			<tr>
-				<th class="nosort" width="30"><input id="id_check_all_runs" type="checkbox" title="Select all/Select none"/></th>
+				<th class="nosort" width="30"><input id="id_check_all_runs" type="checkbox" title="Select all/Select none"></th>
 				<th align="left" class="nosort widthID">ID</th>
 				<th align="left" class="nosort">Test Run Summary</th>
-				<th align="left" class="nosort" width="80" >Manager</th>
-				<th align="left" class="nosort" width="120" >Default Tester</th>
-				<th align="left" class="nosort" width="150" >Start date</th>
-				<th align="left" class="nosort" width="130" >Build</th>
-				<th align="center" class="nosort" width="70" >Status</th>
-				<th align="left" class="nosort" width="50" >Cases</th>
-				<th align="left" class="nosort" width="110" >Failure</th>
-				<th align="left" class="nosort" width="110" >Success</th>
+				<th align="left" class="nosort" width="80">Manager</th>
+				<th align="left" class="nosort" width="120">Default Tester</th>
+				<th align="left" class="nosort" width="150">Start date</th>
+				<th align="left" class="nosort" width="130">Build</th>
+				<th align="center" class="nosort" width="70">Status</th>
+				<th align="left" class="nosort" width="50">Cases</th>
+				<th align="left" class="nosort" width="110">Failure</th>
+				<th align="left" class="nosort" width="110">Success</th>
 			</tr>
 		</thead>
 		<tbody id="testruns_body"></tbody>
 	</table>
+
 	<div id="img_loading_runs" class="ajax_loading" style="display:none;"></div>
 </form>

--- a/tcms/templates/run/all.html
+++ b/tcms/templates/run/all.html
@@ -51,12 +51,8 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.List.on_load);
 		{# <span class="tit">{{ test_runs.count }} Test Runs</span> #}
 		<span class="tit"><a href="{% url "tcms.testruns.views.all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
 		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param='{% url "tcms.testruns.views.clone" %}' />
-		<input class="progress" type="button"
-				value="Calculate Progress" id="btn_selected_progress"
-				title="calculate progress of selected test runs"/>
 	</div>
 	{% include "run/common/run_filtered.html" %}
-	
 	{% else %}
 	{% if query_result %}
 	<span class="prompt-message"><center>No test runs found</center></span>

--- a/tcms/templates/run/common/json_runs.txt
+++ b/tcms/templates/run/common/json_runs.txt
@@ -1,34 +1,31 @@
 {
-    "sEcho": {{sEcho}},
-    "iTotalRecords": {{iTotalRecords}},
-    "iTotalDisplayRecords": {{iTotalDisplayRecords}},
-    "aaData":[
-    {% for test_run in querySet %}
-    [
-        "<input type='checkbox' name='run' value='{{ test_run.pk }}' class='run_selector'>",
-        "<a href='{% url "tcms.testruns.views.get" test_run.run_id %}' >{{ test_run.run_id }}</a>",
-        "<a href='{% url "tcms.testruns.views.get" test_run.run_id %}' >{{ test_run.summary }}</a>",
-        "<a href='{% url "tcms.profiles.views.profile" test_run.manager.username %}'>{{ test_run.manager }}</a>",
-        {% if test_run.default_tester_id %}
-            "<a href='{% url "tcms.profiles.views.profile" test_run.default_tester.username %}'>{{test_run.default_tester}}</a>"
-        {% else %}
-            "{{test_run.default_tester}}"
-        {% endif %},
-        "{{test_run.plan}}",
-        "{{test_run.build.product}}",
-        "{{test_run.product_version}}",
-        "{{test_run.env_groups}}",
-        "{{test_run.total_num_caseruns}}",
-        {% if test_run.stop_date %}
-            "<span class='pauselink'>Finished</span>"
-        {% else %}
-            "<span class='runninglink'>Running</span>"
-        {% endif %},
-        "<a href='#statistics' class='btn-statistics' run='{{test_run.run_id}}'>calculate</a><div class='progress-bar' style='display: none;'><div class='progress-inner'><div class='progress-failed'></div></div><div class='percent'></div></div>"
-        ]
-    {% if not forloop.last %}
-    ,
-    {% endif %}
-    {% endfor %}
-    ]
+	"sEcho": {{ sEcho }},
+	"iTotalRecords": {{ iTotalRecords }},
+	"iTotalDisplayRecords": {{ iTotalDisplayRecords }},
+	"aaData":[
+	{% for run in runs %}
+	[
+		"<input type='checkbox' name='run' value='{{  run.pk  }}' class='run_selector'>",
+		"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{  run.run_id  }}</a>",
+		"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{  run.summary  }}</a>",
+		"<a href='{% url "tcms.profiles.views.profile" run.manager.username %}'>{{  run.manager  }}</a>",
+		{% if run.default_tester_id %}
+			"<a href='{% url "tcms.profiles.views.profile" run.default_tester.username %}'>{{ run.default_tester }}</a>"
+		{% else %}
+			"{{ run.default_tester }}"
+		{% endif %},
+		"{{ run.plan }}",
+		"{{ run.build.product }}",
+		"{{ run.product_version }}",
+		"{{ run.env_groups }}",
+		"{{ run.total_num_caseruns }}",
+		{% if run.stop_date %}
+			"<span class='pauselink'>Finished</span>"
+		{% else %}
+			"<span class='runninglink'>Running</span>"
+		{% endif %},
+	        "<div style='' class='progress-bar'><div class='progress-inner' style='width: {{ run.nitrate_stats.completed_percent|floatformat:2 }}px;'><div class='progress-failed' style='width: {{ run.nitrate_stats.failed_percent|floatformat:2 }}px;'></div></div><div class='percent'>{{ run.nitrate_stats.completed_percent|floatformat:2 }}%</div></div>"
+		]{% if not forloop.last %},{% endif %}
+	{% endfor %}
+	]
 }

--- a/tcms/templates/search/runs.html
+++ b/tcms/templates/search/runs.html
@@ -10,10 +10,6 @@
 	<div id="contentTab" class="mixbar">
 		<span class="tit"><a href="{% url "tcms.testruns.views.all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
 		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param="{% url "tcms.testruns.views.clone" %}" />
-		
-		<input class="progress" type="button"
-				value="Calculate Progress" id="btn_selected_progress"
-				title="calculate progress of selected test runs"/>
 		<span class="right-action">{% paginate %}</span>
 	</div>
 	{% include "run/common/run_advance_filtered.html" %}

--- a/tcms/testplans/urls/plan_urls.py
+++ b/tcms/testplans/urls/plan_urls.py
@@ -15,8 +15,8 @@ urlpatterns = patterns('tcms.testplans.views',
                        url(r'^(?P<plan_id>\d+)/cases/$', 'cases'),
                        )
 
-urlpatterns += patterns('tcms.testruns.views',
-                        url(r'^(?P<plan_id>\d+)/runs/$',
-                            'load_runs_of_one_plan',
-                            name='load_runs_of_one_plan_url'),
-                        )
+urlpatterns += patterns(
+    'tcms.testruns.views',
+    url(r'^(?P<plan_id>\d+)/runs/$', 'load_runs_of_one_plan',
+        name='load_runs_of_one_plan_url'),
+    )

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import datetime
 import itertools
 import urllib

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -337,7 +337,7 @@ class PlanFilterRunForm(forms.Form):
         required=False
     )
     manager__username__iexact = UserField(required=False)
-    plan = forms.CharField(required=True)
+    plan = forms.IntegerField(required=True)
     run_id = forms.CharField(required=False)
     start_date__gt = forms.DateTimeField(required=False)
     summary__icontains = forms.CharField(required=False)

--- a/tcms/testruns/urls/run_urls.py
+++ b/tcms/testruns/urls/run_urls.py
@@ -29,5 +29,4 @@ urlpatterns = patterns(
     url(r'^(?P<run_id>\d+)/cc/$', 'cc'),
     url(r'^(?P<run_id>\d+)/update/$', 'update_case_run_text'),
     url(r'^(?P<run_id>\d+)/export/$', 'export'),
-    url(r'^(?P<run_id>\d+)/percent/$', 'caserun_of_the_status_in_percentage'),
 )


### PR DESCRIPTION
Two places to show test runs within DataTable, they are Search Runs and
Runs tab in a plan page.

* Unused code is cleaned (removed).
* Using DataTable to show test runs. Runs are paginated and to get each
  page of runs by an AJAX request.
* Refactored TestRun.list by a table-driven method. Lots of lines of
  code are saved.
* python-six is now a dependency
* reformat template files