### PR TITLE
Update link to wadofstuff-django-serializers. Fixes #99

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+master (unreleased)
+-------------------
+
+- Update link to wadofstuff-django-serializers. Fixes #99 (Mr. Senko)
+
 3.8.18 (Aug 21 2016)
 --------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ MySQL-python==1.2.5
 kerberos==1.1.1
 qpid-python==0.20
 django-uuslug==1.0.0
-https://wadofstuff.googlecode.com/files/wadofstuff-django-serializers-1.1.0.tar.gz#egg=wadofstuff-django-serializers
+wadofstuff-django-serializers==1.1.0
 django-celery>=3.1.10
 https://git.fedorahosted.org/cgit/kobo.git/snapshot/kobo-0.2.1.tar.gz#egg=kobo
 odfpy>=0.9.6


### PR DESCRIPTION
Minor update to requirements so they can install. Fixes #99. 

I was not sure if changelog was updated automatically or not so I've updated it by hand. Let me know if you want to remove it.