### PR TITLE
Require celery<4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,7 @@ qpid-python==0.20
 django-uuslug==1.0.0
 https://wadofstuff.googlecode.com/files/wadofstuff-django-serializers-1.1.0.tar.gz#egg=wadofstuff-django-serializers
 django-celery>=3.1.10
+celery>=3.1.15,<4.0
 https://git.fedorahosted.org/cgit/kobo.git/snapshot/kobo-0.2.1.tar.gz#egg=kobo
 odfpy>=0.9.6
 django-pagination==1.0.7


### PR DESCRIPTION
django-celery has fixed the requirements in
https://github.com/celery/django-celery/commit/4ed4067e94e141a37baa7b085906766fb162d676
but hasn't released any new versions yet.