### PR TITLE
Update documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Change Log
 3.9 (Unreleased)
 ----------------
 
+- Updated documentation with sections about hosting with
+  Gunicorn, Docker and Google Cloud Engine (Mr. Senko)
 - Remove raw SQL migrations and initial schema and data
 - Add migration for django_comments
 - Upgrade Django to 1.8.14

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -14,8 +14,8 @@ Key features
 A brief history
 ---------------
 
-Dependences
------------
+Dependencies
+------------
 
 Basic dependences::
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -63,8 +63,8 @@ contact Nitrate team to disucss your ideas and implement it. Following these
 steps to contribute code to Nitrate.
 
 
-Get code
-~~~~~~~~
+Get the code
+~~~~~~~~~~~~
 
 Code is hosted in Github. Following the guide in Github to fork and clone
 code to your local machine. For example, I have forked Nitrate, then I can
@@ -73,6 +73,12 @@ clone it
 ::
 
     git clone git@github.com:[my github username]/Nitrate.git
+
+
+Start Nitrate locally
+~~~~~~~~~~~~~~~~~~~~~
+
+See :doc:`set_dev_env` or :doc:`set_dev_env_with_vagrant` for more information!
 
 
 Confirm the problem

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,8 @@ Contents
    set_dev_env.rst
    set_dev_env_with_vagrant.rst
    installing_in_rhel.rst
+   installing_gunicorn.rst
+   installing_gce.rst
    tutorial.rst
    contribution.rst
    faq.rst

--- a/docs/source/installing_gce.rst
+++ b/docs/source/installing_gce.rst
@@ -1,0 +1,177 @@
+.. _deployment:
+
+Installing Nitrate with Docker and Google Cloud Engine
+======================================================
+
+It is possible to host Nitrate on Google Cloud Engine as a Docker image.
+The image is configured to use Gunicorn as the backend server. To read
+more about Nitrate and Gunicorn see :doc:`installing_gunicorn`.
+
+.. warning::
+
+    You need docker running on the local machine and google-cloud-sdk installed
+    and configured with proper credentials in order for the commands below to work!
+
+
+Create Docker image
+-------------------
+
+First make sure you are able to start Nitrate via Gunicorn locally!
+Then inside your application directory create the following files.
+
+``app.yaml``::
+
+    # Copyright 2015 Google Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    # This file specifies your Python application's runtime configuration.
+    # See https://cloud.google.com/appengine/docs/managed-vms/config for details.
+    runtime: custom
+    vm: true
+    entrypoint: custom
+
+Use the following ``Dockerfile`` to build your image::
+
+    # Copyright 2015 Google Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License
+    
+    # The Google App Engine python runtime is Debian Jessie with Python installed
+    # and various os-level packages to allow installation of popular Python
+    # libraries. The source is on github at:
+    #   https://github.com/GoogleCloudPlatform/python-docker
+    FROM gcr.io/google_appengine/python
+
+    # Create a virtualenv for the application dependencies.
+    RUN virtualenv /env
+
+    # Set virtualenv environment variables. This is equivalent to running
+    # source /env/bin/activate. This ensures the application is executed within
+    # the context of the virtualenv and will have access to its dependencies.
+    ENV VIRTUAL_ENV /env
+    ENV PATH /env/bin:$PATH
+
+    # update the base OS image
+    RUN apt-get update
+    RUN apt-get upgrade -y
+
+    # install packages needed to build the Python dependencies
+    RUN apt-get install -y libkrb5-dev mysql-client
+
+    RUN pip install -U pip
+
+    # Install gunicorn and Nitrate
+    # remove django-s3-folder-storage if you don't use Amazon S3 for static files
+    RUN pip install gunicorn nitrate django-s3-folder-storage
+
+    # Add application code.
+    ADD . /app
+
+    # Gunicorn is used to run the application on Google App Engine. $PORT is defined
+    # by the runtime.
+    CMD gunicorn -b :$PORT --keyfile /app/ssl/key.pem --certfile /app/ssl/cert.pem mynitrate.wsgi
+
+.. note::
+
+    ``ssl/`` is a directory containing SSL key and certificate if you'd like to serve
+    Nitrate via HTTPS.
+
+.. warning::
+
+    At the time of writing Nitrate is not distributed as a package hosted on
+    Python Package Index. The command ``pip install nitrate`` above will fail
+    unless you provide it with the exact URL to ``nitrate-X.Y.tar.gz``! You can
+    build the package on your own using ``python ./setup.py sdist``!
+
+
+Build and push the latest version of the image
+----------------------------------------------
+
+::
+
+    $ IMAGE="gcr.io/YOUR-ORGANIZATION/nitrate:v$(date +%Y%m%d%H%M)"
+    $ docker build --tag $IMAGE .
+    $ gcloud docker push $IMAGE
+
+
+To view all images::
+
+    $ docker images
+
+Create the service for the first time
+-------------------------------------
+
+::
+
+    $ kubectl run nitrate --image=gcr.io/YOUR-ORGANIZATION/nitrate:vYYYYMMDDHHMM --port 8080
+    $ kubectl expose rc nitrate --port 443 --target-port 8080 --name nitrate-https --type=LoadBalancer
+
+These commands will create a resource controller with a single pod running the
+service. After a while you can view the external IP address using the command::
+
+    $ kubectl get svc
+
+Other useful commands (for debugging) are::
+
+    $ kubectl get rc
+    $ kubectl get pods
+
+
+Create DB structure, first user and upload static files
+-------------------------------------------------------
+
+The commands below are executed from inside the Docker image
+because they need access to ``mynitrate/settings.py``::
+
+
+    $ kubectl get pods
+    NAME            READY     STATUS    RESTARTS   AGE
+    nitrate-d2u6p   1/1       Running   0          18h
+    
+    $ kubectl exec nitrate-d2u6p -i -t -- bash -il
+    root@nitrate-d2u6p:/home/vmagent/app# source /env/bin/activate
+    (env)root@nitrate-d2u6p:/home/vmagent/app# PYTHONPATH=. django-admin migrate --settings mynitrate.settings
+    (env)root@nitrate-d2u6p:/home/vmagent/app# PYTHONPATH=. django-admin createsuperuser --settings mynitrate.settings
+    (env)root@nitrate-d2u6p:/home/vmagent/app# PYTHONPATH=. django-admin collectstatic --noinput --settings mynitrate.settings
+
+
+Updating to new version
+-----------------------
+
+* Update Nitrate code and/or settings;
+* Create a new Docker image version and upload it to Google Container Engine;
+* Update the service to use the latest version of the Docker image::
+
+    $ kubectl rolling-update nitrate --image=gcr.io/YOUR-ORGANIZATION/nitrate:vYYYYMMDDHHMM
+
+where you pass the latest version to the ``--image`` parameter;
+
+* Update static files (see above).
+
+How To Configure
+----------------
+
+All configuration needs to go into ``mynitrate/settings.py`` **BEFORE** you build the
+Docker image and push it to GCE.
+

--- a/docs/source/installing_gunicorn.rst
+++ b/docs/source/installing_gunicorn.rst
@@ -1,0 +1,161 @@
+.. _deployment:
+
+Installing Nitrate with Gunicorn
+================================
+
+Installation
+------------
+
+Start by creating a virtualenv for your Nitrate instance::
+
+    $ mkvirtualenv myNitrate
+
+Install Gunicorn::
+
+    (myNitrate)$ pip install gunicorn
+
+Install Nitrate::
+
+    (myNitrate)$ cd ~/path/to/Nitrate
+    (myNitrate)$ python ./setup.py install
+
+
+Configuration
+--------------
+
+You need to create a directory holding customized settings to your Nitrate
+instance and a ``wsgi.py`` file for Gunicorn::
+
+    (myNitrate)$ mkdir mynitrate
+
+The ``mynitrate/`` directory needs to contain the following files::
+
+    (myNitrate)$ ls -l mynitrate/
+    total 0
+    -rw-rw-r--. 1 atodorov atodorov    0 Jan 26 11:41 __init__.py
+    -rw-rw-r--. 1 atodorov atodorov 1300 Jan 26 11:41 settings.py
+    -rw-rw-r--. 1 atodorov atodorov  170 Jan 26 11:41 wsgi.py
+
+``__init__.py`` must be empty. The other files should look like shown below.
+
+``mynitrate/wsgi.py``::
+
+    import os
+    
+    from django.core.wsgi import get_wsgi_application
+    
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mynitrate.settings")
+    
+    application = get_wsgi_application()
+
+
+``mynitrate/settings.py``::
+
+    from tcms.settings.product import *
+    
+    
+    # SECURITY WARNING: keep the secret key used in production secret!
+    SECRET_KEY = 'top-secret'
+    
+    # SECURITY WARNING: don't run with debug turned on in production!
+    DEBUG = False
+    
+    # Database settings
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'changeMe',
+            'HOST': 'changeMe',
+            'USER': 'changeMe',
+            'PASSWORD': 'changeMe',
+        },
+    }
+    # Nitrate defines a 'slave_1' connection
+    DATABASES['slave_1'] = DATABASES['default']
+
+Static files storage with Amazon S3
+-----------------------------------
+
+You will also have to configure static files storage for all images, CSS and
+JavaScript content. Static files need not be served by Gunicorn directly.
+If you want to have Nginx serve them take a look at
+http://honza.ca/2011/05/deploying-django-with-nginx-and-gunicorn.
+
+Another very easy and cheap way to host your static files is to
+use Amazon S3. If you decide to do this then::
+
+    (myNitrate)$ pip install django-s3-folder-storage
+
+and add the following configuration to `mynitrate/settings.py`::
+
+    INSTALLED_APPS += (
+        's3_folder_storage',
+    )
+    
+    # static files storage
+    AWS_S3_ACCESS_KEY_ID = "changeMe"
+    AWS_S3_SECRET_ACCESS_KEY = "changeMe"
+    AWS_STORAGE_BUCKET_NAME = "changeMe"
+    
+    STATICFILES_STORAGE = 's3_folder_storage.s3.StaticStorage'
+    STATIC_S3_PATH = "static"
+    STATIC_URL = '//s3.amazonaws.com/%s/%s/' % (AWS_STORAGE_BUCKET_NAME, STATIC_S3_PATH)
+
+.. warning::
+
+    Amazon S3 Frankfurt supports only Sigv4 requests so you need to properly
+    instruct the storages layer to handle them. To work around this create
+    a file named ``mynitrate/storage.py`` with the following content::
+
+        import os
+        from s3_folder_storage.s3 import StaticStorage
+        
+        os.environ['S3_USE_SIGV4'] = 'True'
+        class SigV4Storage(StaticStorage):
+            @property
+            def connection(self):
+                if self._connection is None:
+                    self._connection = self.connection_class(
+                        self.access_key, self.secret_key,
+                        calling_format=self.calling_format, host='s3.eu-central-1.amazonaws.com')
+                return self._connection
+
+    then update your ``mynitrate/settings.py``::
+
+        STATICFILES_STORAGE = 'mynitrate.storage.SigV4Storage'
+        STATIC_URL = '//s3-eu-central-1.amazonaws.com/%s/%s/' % (AWS_STORAGE_BUCKET_NAME, STATIC_S3_PATH)
+
+After static files storage has been configured execute::
+
+    (myNitrate)$ PYTHONPATH=. django-admin collectstatic --settings mynitrate.settings
+
+
+Serve Nitrate with Gunicorn
+---------------------------
+
+Once your local Nitrate instance has been configured then create the database::
+
+    (myNitrate)$ PYTHONPATH=. django-admin migrate --settings mynitrate.settings
+
+Then create the first user account on your Nitrate instance::
+
+    (myNitrate)$ PYTHONPATH=. django-admin createsuperuser --settings mynitrate.settings
+    Username (leave blank to use 'atodorov'): 
+    Email address: atodorov@MrSenko.com
+    Password: 
+    Password (again): 
+    Superuser created successfully.
+
+Afterwards start Gunicorn::
+
+    (myNitrate)$ gunicorn mynitrate.wsgi
+    [2017-01-26 11:52:57 +0000] [24161] [INFO] Starting gunicorn 19.6.0
+    [2017-01-26 11:52:57 +0000] [24161] [INFO] Listening at: http://127.0.0.1:8000 (24161)
+    [2017-01-26 11:52:57 +0000] [24161] [INFO] Using worker: sync
+    [2017-01-26 11:52:57 +0000] [24166] [INFO] Booting worker with pid: 24166
+
+Deployment to production
+------------------------
+
+Gunicorn advises to use Nginx as an HTTP proxy sitting at the front. For more details
+refer to http://gunicorn.org/#deployment.

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -3,4 +3,4 @@
 License
 =======
 
-.. TODO
+.. literalinclude:: ../../LICENSE

--- a/docs/source/set_dev_env.rst
+++ b/docs/source/set_dev_env.rst
@@ -13,7 +13,7 @@ You can get the latest changes with git easily::
 Setup virtualenv
 ----------------
 
-Install devel packages::
+Install devel packages which are needed to compile some of the Python dependencies::
 
     sudo yum install gcc python-devel mysql-devel krb5-devel libxml2-devel libxslt-devel
 
@@ -41,19 +41,29 @@ Create database and user::
 For convenience for development, user, password and database name are already
 set in `tcms/settings/devel.py` with default value. Each of them is `nirrate`.
 
-Load database schema::
+.. note::
 
-    mysql -uroot nitrate < contrib/sql/nitrate_db_setup.sql
+    You may want to adjust the database and/or other configuration settings.
+    Override them in ``./tcms/settings/devel.py`` if necessary. While the
+    Nitrate team prefers MySQL, sqlite appears to work for development
+    and some people have used PostgreSQL with varying success in production!
+    At the moment Nitrate is not 100% portable between database backends
+    due to some hard-coded SQL statements. If you use something other than MySQL
+    some parts of the application may not work correctly!
 
-Load initial data::
+.. warning::
 
-    ./manage.py loaddata contrib/sql/initial_data.json
+    Do not commit local development overrides to GitHub!
 
-Let's run nitrate
+Load database schema and initial data::
+
+    ./manage.py migrate
+
+Let's run Nitrate
 -----------------
 
 You're now ready to start the server::
 
-    python manage.py runserver
+    ./manage.py runserver
 
 Now, open http://127.0.0.1:8000/ and should be presented with your brand new Nitrate homepage!


### PR DESCRIPTION
Several improvements to documentation.

@tkdchen I have added sections on how to configure Nitrate with Gunicorn and serve it as a Docker image in Google Cloud Engine. I have one such setup which I created using the documented instructions and I wanted to share them. 

I also have another instance of Nitrate hosted on Red Hat's OpenShift cloud and I will create another file documenting how to get that up and running.