### PR TITLE
Install kobo from source

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,5 +13,4 @@ six
 django-contrib-comments
 django-preserialize
 
-# Packages that cannot be installed from PyPI
-# kobo-django>=0.5.2
+git+https://github.com/release-engineering/kobo.git@kobo-0.5.2#egg=kobo


### PR DESCRIPTION
This patch make it possible to install kobo including the required
kobo-django from source directly.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>