### PR TITLE
Fix regression & update help strings when clonning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 ----------------
 
 - Drop support for Python 2.6 (Mr. Senko)
+- Update help strings of clone case form and update docs. Fix #67 (Mr. Senko)
 - Updated documentation with sections about hosting with
   Gunicorn, Docker and Google Cloud Engine (Mr. Senko)
 - Remove raw SQL migrations and initial schema and data

--- a/docs/source/guide/testcase.rst
+++ b/docs/source/guide/testcase.rst
@@ -352,11 +352,13 @@ To clone a Test Case:
 #. Click the Plans to clone this Test Case to.
 #. Select **Case Properties**:
 
-   -  Create a Copy - Unchecking will create a link to the selected Test
+   -  Create a copy - Unchecking will create a link to the selected Test
       Case.
    -  Keep original author - untick to make current user the author.
-   -  Copy the component to new product - unchecking will remove
-      component from the cloned Test Case.
+   -  Copy test case components to the product of selected Test Plan
+      (Unchecking will remove components from copied test case).
+   -  Copy test case attachments (Unchecking will remove attachments of copied
+      test case).
 
 #. Click **Clone**.
 

--- a/tcms/testcases/forms.py
+++ b/tcms/testcases/forms.py
@@ -471,7 +471,7 @@ class CloneCaseForm(forms.Form):
     )
     copy_case = forms.BooleanField(
         label='Create a copy',
-        help_text='Create a Copy (Unchecking will create a link to selected '
+        help_text='Create a copy (Unchecking will create a link to selected '
                   'case)',
         required=False
     )
@@ -488,14 +488,14 @@ class CloneCaseForm(forms.Form):
         required=False
     )
     copy_component = forms.BooleanField(
-        label='Copy the component to new product you specific',
-        help_text='Copy the component to new product you specific ('
-                  'Unchecking will remove component of copied test case)',
+        label='Copy test case components to the product of selected Test Plan',
+        help_text='Copy test case components to the product of selected Test Plan ('
+                  'Unchecking will remove components from copied test case)',
         required=False
     )
     copy_attachment = forms.BooleanField(
         label='Copy the attachments',
-        help_text='Copy the attachments to new product you specific ('
+        help_text='Copy test case attachments ('
                   'Unchecking will remove attachments of copied test case)',
         required=False
     )

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
+from django.core import serializers
 from django.db.models import Count
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect
@@ -240,6 +241,21 @@ def all(request, template_name='plan/all.html'):
         # I wish to use 'default' argument, as the same as in ModelForm
         # But it does not seem to work
         search_form = SearchPlanForm(initial={'is_active': True})
+
+    if request.GET.get('action') == 'clone_case':
+        template_name = 'case/clone_select_plan.html'
+        tps = tps.order_by('name')
+
+    if request.GET.get('t') == 'ajax':
+        return HttpResponse(serializers.serialize(
+            request.GET.get('f', 'json'),
+            tps,
+            extras=('num_cases', 'num_runs', 'num_children', 'get_url_path')
+        ))
+
+    if request.GET.get('t') == 'html':
+        if request.GET.get('f') == 'preview':
+            template_name = 'plan/preview.html'
 
     query_url = remove_from_request_path(request, 'order_by')
     if asc:


### PR DESCRIPTION
@tkdchen I have updated the help strings for test plan clone form which fixes #67 IMO. Let me know if you approve the text so I can create new screenshot images. 

Note: while testing this I found a regression. You have removed some code in d4f815f which breaks plan filtering. I have added it back. There are 3 if statements, the first one is used when filtering plans during test case cloning. The other 2 I have no idea what they do and if they are needed. 

Can you explain when these if statements are used and why you have deleted them previously ?