### PR TITLE
Update Installing in RHEL docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 - Update help strings of clone case form and update docs. Fix #67 (Mr. Senko)
 - Updated documentation with sections about hosting with
   Gunicorn, Docker and Google Cloud Engine (Mr. Senko)
+- Add documentation about installation with Apache and virtualenv (Mr. Senko)
 - Remove raw SQL migrations and initial schema and data
 - Add migration for django_comments
 - Upgrade Django to 1.8.14

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,5 @@
+Nitrate configuration settings
+==============================
+
+.. literalinclude:: ../../tcms/settings/product.py
+   :language: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,8 +19,11 @@ Contents
    set_dev_env.rst
    set_dev_env_with_vagrant.rst
    installing_in_rhel.rst
+   installing_in_virtualenv.rst
    installing_gunicorn.rst
    installing_gce.rst
+   configuration.rst
+   upgrading.rst
    tutorial.rst
    contribution.rst
    faq.rst

--- a/docs/source/installing_gce.rst
+++ b/docs/source/installing_gce.rst
@@ -1,5 +1,3 @@
-.. _deployment:
-
 Installing Nitrate with Docker and Google Cloud Engine
 ======================================================
 

--- a/docs/source/installing_gunicorn.rst
+++ b/docs/source/installing_gunicorn.rst
@@ -1,5 +1,3 @@
-.. _deployment:
-
 Installing Nitrate with Gunicorn
 ================================
 

--- a/docs/source/installing_in_rhel.rst
+++ b/docs/source/installing_in_rhel.rst
@@ -91,11 +91,10 @@ Like on RHEL6.3, the root path is located in::
     /usr/lib/python2.6/site-packages/nitrate-3.8.6-py2.6.egg/tcms
 
 As we plan to deploy an example server for nitrate, we can use product.py as the
-default settings. After backed up the product.py, please modify following
-settings based on your custom configurations in settings/product.py:
+default settings. After backed up the product.py, please modify
+settings based on your custom configurations in settings/product.py.
+For more information see :doc:`configuration`!
 
-.. literalinclude:: ../../tcms/settings/product.py
-   :language: python
 
 Use cache (Optional)
 --------------------
@@ -188,8 +187,3 @@ If any problem, please refer to log file::
 Or any access info, refer to::
 
     /var/log/httpd/access_log
-
-Upgrading
----------
-
-.. TODO

--- a/docs/source/installing_in_virtualenv.rst
+++ b/docs/source/installing_in_virtualenv.rst
@@ -1,0 +1,167 @@
+Installing Nitrate with Apache (virtualenv) and MySQL
+=====================================================
+
+.. note::
+
+    The steps in this section have been initially written with
+    Red Hat Enterprise Linux 7 in mind. The steps should apply to other
+    Linux distributions as well but file locations may vary!
+
+Install Apache and prepare a local Nitrate directory
+----------------------------------------------------
+
+First install Apache and mod_wsgi if not present::
+
+    # yum install httpd mod_wsgi
+    # systemctl enable httpd
+    # systemctl start httpd
+
+Next create a directory that will host your Nitrate instance::
+
+    # mkdir /var/www/html/mynitrate
+
+Prepare virtualenv
+------------------
+
+You will install Nitrate inside a virtual environment to avoid conflicts with
+system Python libraries and allow for easier upgrade of dependencies::
+
+    # cd /var/www/html/mynitrate
+    # yum install python-virtualenv
+    # virtualenv venv
+    # ./venv/bin/activate
+
+
+Install Nitrate from source code
+--------------------------------
+
+First install RPM packages which are needed to compile some of the Python
+dependencies. See :doc:`set_dev_env` for more information. Then::
+
+    (venv)# cd /home/<username>/
+    (venv)# git clone https://github.com/Nitrate/Nitrate.git
+    (venv)# cd ./Nitrate/
+    (venv)# git checkout --track [a proper tag or branch]
+    (venv)# pip install -r ./requirements/base.txt
+    (venv)# python setup.py install
+
+.. note::
+
+    Nitrate source code has been cloned into your home directory but
+    has been installed into the virtual environment for Apache!
+
+
+Initialize database
+-------------------
+
+Database is required by Nitrate. Django ORM supports many database backends, but
+for the moment we recommend you to use MySQL because some parts of Nitrate do not
+use the ORM layer but instead hand-crafted SQL queries!
+Create database and user for Nitrate in MySQL::
+
+    mysql> create database nitrate;
+    mysql> GRANT all privileges on nitrate.* to nitrate@'%' identified by 'password';
+
+Configure Nitrate
+-----------------
+
+Create the following files.
+
+
+``/var/www/html/mynitrate/__init__.py`` - empty
+
+``/var/www/html/mynitrate/settings.py``::
+
+    from tcms.settings.product import *
+
+    # SECURITY WARNING: keep the secret key used in production secret!
+    SECRET_KEY = 'top-secret'
+    
+    # SECURITY WARNING: don't run with debug turned on in production!
+    DEBUG = False
+
+    # Database settings
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'nitrate',
+            'HOST': '',
+            'USER': 'nitrate',
+            'PASSWORD': 'password',
+        },
+    }
+    # Nitrate defines a 'slave_1' connection
+    DATABASES['slave_1'] = DATABASES['default']
+    
+    STATIC_ROOT = '/var/www/html/mynitrate/static'
+
+
+``/var/www/html/mynitrate/wsgi.py``::
+
+    import os
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    
+    from django.core.wsgi import get_wsgi_application
+    application = get_wsgi_application()
+
+
+Create tables, create super user and collect static files::
+
+    (venv)# cd /var/www/html/mynitrate
+    (venv)# django-admin.py migrate --settings=settings
+    (venv)# django-admin.py createsuperuser --settings=settings
+    (venv)# django-admin.py collectstatic --settings=settings
+
+Verify that your configuration works by::
+
+    (venv)# django-admin.py runserver --settings=settings
+
+.. note::
+
+    For more information about Nitrate configuration see
+    :doc:`configuration`!
+
+Create upload directory
+-----------------------
+
+Create upload directory and change owner & group to ``apache``::
+
+    # mkdir -p /var/nitrate/uploads
+    # chown apache:apache /var/nitrate/uploads
+
+
+Configure Apache and mod_wsgi
+-----------------------------
+
+``/etc/httpd/conf.d/nitrate.conf``::
+
+    WSGIDaemonProcess nitrateapp python-path=/var/www/html/mynitrate:/var/www/html/mynitrate/venv/lib/python2.7/site-packages
+    WSGIProcessGroup nitrateapp
+    WSGIScriptAlias / /var/www/html/mynitrate/wsgi.py
+
+    Alias /static/ /var/www/html/mynitrate/static/
+
+    <Location "/static/">
+        Options -Indexes
+    </Location>
+
+Then restart Apache::
+
+    # systemctl restart httpd
+
+
+In case of problem, refer to log file::
+
+    /var/log/httpd/error_log
+
+For access info, refer to::
+
+    /var/log/httpd/access_log
+
+
+Apache and mod_wsgi can be configured in many ways. Another example of
+Apache configuration for Nitrate is shown below. You will very likely
+have to adjust it based on your particular environment.
+
+.. literalinclude:: ../../contrib/conf/nitrate-httpd.conf
+   :language: bash

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -1,0 +1,4 @@
+Upgrading
+=========
+
+.. TODO


### PR DESCRIPTION
@tkdchen 

- updated for RHEL 7
- the preferred way to install is using virtualenv
- simplified WSGI config but kept reference to previous example
- split Upgrading and Configuration in separate sections b/c I
  intend to write more info for that

Note: the biggest change is installing with virtualenv and not directly into the system path. I believe virtualenv is the preferred way to host Django (and Python) applications. At least sites like DigitalOcean recommend it. It provides benefits and doesn't really add a lot of overhead when creating the environment so IMO this is an acceptable change.