### PR TITLE
Replace nose with pytest to run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,7 @@ endif
 
 .PHONY: test
 test:
-	@./manage.py test --settings=tcms.settings.test \
-		--pattern test_*.py --exclude TestCase --exclude TestPlan $(TEST_TARGET)
+	@pytest $(TEST_TARGET)
 
 
 .PHONY: check

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -3,6 +3,6 @@ django-debug-toolbar==1.4
 Sphinx>=1.1.2
 flake8
 epydoc==3.0.1
-django-nose
-django-coverage
+pytest-django
+pytest-cov
 coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,17 @@ formats = bztar
 [flake8]
 max-line-length = 100
 
-[nosetests]
-with-coverage = 1
-cover-erase = 1
-cover-html = 1
-cover-html-dir = cover-report
-cover-package = tcms
-nologcapture = 1
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = tcms.settings.test
+python_files = tests.py tests/test_*.py
+
+# This magic value causes py.test does not collect arbitrary classes, like
+# Nitrate's TestCase, TestPlan, and TestRun, that are wrongly treated as tests.
+# This value lets py.test only collect classes that is derived from either
+# django.test.TestCase or unittest.TestCase
+# So, if anyone writes a test class with a name including this string, it is
+# incorrect.
+# Refer to http://doc.pytest.org/en/latest/customize.html#confval-python_classes
+python_classes = *xxxxxxxxx*
+
+addopts = -vv --cov=tcms/ --cov-report=term

--- a/tcms/settings/test.py
+++ b/tcms/settings/test.py
@@ -11,10 +11,6 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS += ('django_nose',)
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
 LISTENING_MODEL_SIGNAL = False
 
 LOGGING = {


### PR DESCRIPTION
This patch replaces nose with pytest as the test runner to run tests due
to several major reasons.

- nose is currently in maintenance mode and will not have new features
  in the future, whereas pytest has active development in contrast.

- Nitrate is a little special with its core class names, e.g. TestCase,
  TestPlan, TestRun, all these names could confuse nose easily to treat
  them as a test rather than a normal feature class. The runner only
  requires to collect classes derived from either django.test.TestCase
  or unittest.TestCase. pytest makes this easier to implement with less
  and easy-to-understand configuration.

- As a result of using pytest, runnng test is simplified. Just
  `py.test'. There is no default test runner for integrating with
  django's test command, but it's easy to write one by referring to
  pytest-django documentation. I don't add a runner at this moment.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>