### PR TITLE
Remove tcms.core.migrations.0001_django_comments__object_pk

### DIFF
--- a/tcms/core/migrations/0001_django_comments__object_pk.py
+++ b/tcms/core/migrations/0001_django_comments__object_pk.py
@@ -1,19 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
-    dependencies = [
-        ('django_comments', '__latest__'),
-    ]
-
-    operations = [
-        migrations.AlterField('comment', 'object_pk', models.IntegerField())
-    ]
-
-    def __init__(self, name, app_label):
-        super(Migration, self).__init__(name, app_label)
-        self.app_label = 'django_comments'
+    """
+        Empty migration. Removed in #157.
+    """
+    pass

--- a/tcms/core/migrations/0002_add_initial_data.py
+++ b/tcms/core/migrations/0002_add_initial_data.py
@@ -27,6 +27,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('core', '0001_django_comments__object_pk'),
+        ('sites', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
this migration is modifying a 3rd party model and was overriding
app_label to django_comments in order to gain access to the model!

However due to how Django records executed migrations it was
recorded as django_comments|0001... instead of core|0001...! Thus
the migration was seen as still pending and could lead to problems
when applying further migrations.

@tkdchen please review. I think we've got the migration right this time.