### PR TITLE
Refactor SQLs in xmlrpc (with tests)

### DIFF
--- a/tcms/xmlrpc/api/testcase.py
+++ b/tcms/xmlrpc/api/testcase.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import itertools
-
 from itertools import imap
 
 from django.conf import settings
@@ -18,7 +16,6 @@ from tcms.testcases.models import TestCase
 from tcms.testcases.models import TestCasePlan
 from tcms.testplans.models import TestPlan
 from tcms.xmlrpc.decorators import log_call
-from tcms.xmlrpc.sqls import TC_REMOVE_CC
 from tcms.xmlrpc.utils import distinct_count
 from tcms.xmlrpc.utils import pre_process_estimated_time
 from tcms.xmlrpc.utils import pre_process_ids
@@ -1246,13 +1243,10 @@ def notification_remove_cc(request, case_ids, cc_list):
 
     try:
         tc_ids = pre_process_ids(case_ids)
-        cursor = connection.writer_cursor
-        ids_values = ",".join(itertools.repeat('%s', len(tc_ids)))
-        email_values = ",".join(itertools.repeat('%s', len(cc_list)))
-        sql = TC_REMOVE_CC % (ids_values, email_values)
-        tc_ids.extend(cc_list)
-        cursor.execute(sql, tc_ids)
-        transaction.commit_unless_managed()
+
+        for tc in TestCase.objects.filter(pk__in=tc_ids).only('pk').iterator():
+            tc.emailing.remove_cc(cc_list)
+
     except (TypeError, ValueError, Exception):
         raise
 

--- a/tcms/xmlrpc/sqls.py
+++ b/tcms/xmlrpc/sqls.py
@@ -1,11 +1,3 @@
-TP_CLEAR_ENV_GROUP = '''
-DELETE FROM `tcms_env_plan_map` where plan_id in (%s)
-'''
-
-TP_ADD_ENV_GROUP = '''
-INSERT INTO `tcms_env_plan_map` (`plan_id`, `group_id`) values %s
-'''
-
 TC_REMOVE_CC = '''
 DELETE contact
 FROM `testcases_testcaseemailsettings` eset

--- a/tcms/xmlrpc/sqls.py
+++ b/tcms/xmlrpc/sqls.py
@@ -1,7 +1,0 @@
-TC_REMOVE_CC = '''
-DELETE contact
-FROM `testcases_testcaseemailsettings` eset
-JOIN `tcms_contacts` contact ON (eset.id = contact.object_pk)
-WHERE eset.case_id IN (%s)
-  AND contact.email IN (%s);
-'''

--- a/tcms/xmlrpc/tests/test_testcase.py
+++ b/tcms/xmlrpc/tests/test_testcase.py
@@ -1,1 +1,46 @@
 # -*- coding: utf-8 -*-
+
+from django import test
+
+from tcms.xmlrpc.api import testcase as XmlrpcTestCase
+from tcms.xmlrpc.tests.utils import make_http_request
+from tcms.xmlrpc.tests.utils import user_should_have_perm
+
+from tcms.tests.factories import TestCaseFactory
+from tcms.tests.factories import UserFactory
+
+__all__ = (
+    'TestNotificationRemoveCC',
+)
+
+
+class TestNotificationRemoveCC(test.TestCase):
+    """ Tests the XMLRPM testcase.notication_remove_cc method """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestNotificationRemoveCC, cls).setUpClass()
+
+        cls.user = UserFactory()
+        cls.http_req = make_http_request(user=cls.user)
+        perm_name = 'testcases.change_testcase'
+        user_should_have_perm(cls.http_req.user, perm_name)
+
+        cls.default_cc = 'example@MrSenko.com'
+        cls.testcase = TestCaseFactory()
+        cls.testcase.emailing.add_cc(cls.default_cc)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.testcase.emailing.cc_list.all().delete()
+        cls.testcase.delete()
+        cls.user.delete()
+        super(TestNotificationRemoveCC, cls).tearDownClass()
+
+    def test_remove_existing_cc(self):
+        # initially testcase has the default CC listed
+        # and we issue XMLRPC request to remove the cc
+        XmlrpcTestCase.notification_remove_cc(self.http_req, self.testcase.pk, [self.default_cc])
+
+        # now verify that the CC email has been removed
+        self.assertEqual(0, self.testcase.emailing.cc_list.count())

--- a/tcms/xmlrpc/tests/test_testplan.py
+++ b/tcms/xmlrpc/tests/test_testplan.py
@@ -17,6 +17,7 @@ from tcms.testcases.models import TestCase
 from tcms.testcases.models import TestCasePlan
 from tcms.testcases.models import TestCaseStatus
 from tcms.testplans.models import TestPlan
+from tcms.testplans.models import TCMSEnvPlanMap
 from tcms.xmlrpc.api import testplan as XmlrpcTestPlan
 from tcms.xmlrpc.api.testplan import clean_xml_file
 from tcms.xmlrpc.api.testplan import process_case
@@ -29,6 +30,7 @@ from tcms.tests.factories import TestCaseFactory
 from tcms.tests.factories import TestPlanFactory
 from tcms.tests.factories import TestPlanTypeFactory
 from tcms.tests.factories import TestTagFactory
+from tcms.tests.factories import TCMSEnvGroupFactory
 from tcms.tests.factories import UserFactory
 from tcms.tests.factories import VersionFactory
 from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
@@ -375,9 +377,68 @@ class TestImportCaseViaXML(test.TestCase):
     '''TODO: '''
 
 
-@unittest.skip('TODO: test case is not implemented yet.')
 class TestUpdate(test.TestCase):
-    '''TODO: '''
+    """ Tests the XMLRPM testplan.update method """
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestUpdate, cls).setUpClass()
+
+        cls.user = UserFactory()
+        cls.http_req = make_http_request(user=cls.user)
+        perm_name = 'testplans.change_testplan'
+        user_should_have_perm(cls.http_req.user, perm_name)
+
+        cls.env_group_1 = TCMSEnvGroupFactory()
+        cls.env_group_2 = TCMSEnvGroupFactory()
+        cls.product = ProductFactory()
+        cls.version = VersionFactory(product=cls.product)
+        cls.tester = UserFactory()
+        cls.plan_type = TestPlanTypeFactory(name='manual smoking')
+        cls.plan_1 = TestPlanFactory(product_version=cls.version,
+                                     product=cls.product,
+                                     author=cls.tester,
+                                     type=cls.plan_type,
+                                     env_group=(cls.env_group_1,))
+        cls.plan_2 = TestPlanFactory(product_version=cls.version,
+                                     product=cls.product,
+                                     author=cls.tester,
+                                     type=cls.plan_type,
+                                     env_group=(cls.env_group_1,))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.plan_1.delete()
+        cls.plan_2.delete()
+        cls.plan_type.delete()
+        cls.tester.delete()
+        cls.user.delete()
+        cls.version.delete()
+        cls.product.delete()
+        cls.product.classification.delete()
+        cls.env_group_1.delete()
+        cls.env_group_2.delete()
+        super(TestUpdate, cls).tearDownClass()
+
+    def test_update_env_group(self):
+        # plan_1 and plan_2 point to self.env_group_1
+        # and there are only 2 objects in the many-to-many table
+        # so we issue XMLRPC request to modify the env_group of self.plan_2
+        plans = XmlrpcTestPlan.update(self.http_req, self.plan_2.pk, {'env_group': self.env_group_2.pk})
+        plan = plans[0]
+
+        # now verify that the returned TP (plan_2) has been updated to env_group_2
+        self.assertEqual(self.plan_2.pk, plan['plan_id'])
+        self.assertEqual(1, len(plan['env_group']))
+        self.assertEqual(self.env_group_2.pk, plan['env_group'][0])
+
+        # and that plan_1 has not changed at all
+        self.assertEqual(1, self.plan_1.env_group.count())
+        self.assertEqual(self.env_group_1.pk, self.plan_1.env_group.all()[0].pk)
+
+        # and there are still only 2 objects in the many-to-many table
+        # iow no dangling objects left
+        self.assertEqual(2, TCMSEnvPlanMap.objects.filter(plan__in=[self.plan_1, self.plan_2]).count())
 
 
 # ################ Section for testing testplan.import_case_via_XML ########


### PR DESCRIPTION
More SQL refactoring into ORM, this time with working tests.

*NOTE:* the last commit where I add a test for `xmlrpc.testcase.notification_remove_cc` is a bit problematic. If I execute it on its own everything seems to work. If I execute `make check` pyunit produces a core dump. As of now I have not been able to identify why but I suspect it has to do with the creating/deleting the test objects themselves.

EDIT: found the culprit of the core dump - I wasn't deleting the cc emails and user objects created by my test. Already fixed.