### PR TITLE
Enable Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
 python:
   - "2.7"
+before_install:
+  - pip install coveralls
 install: "pip install -r requirements/devel.txt"
 script: make check
+after_success:
+  - coveralls
 notifications:
   email:
     on_failure: change


### PR DESCRIPTION
after a successfull build Travis-CI will send coverage information to coveralls.io. 

@tkdchen if you enable Coveralls for the Nitrate/Nitrate repo it will start working automatically. Also we can then add a nice badge to the README showing how much coverage we've got. Coveralls also records the history so you can traverse how coverage did change over time. Here's an example from another project I am working on: https://coveralls.io/github/chartit/django-chartit
