### PR TITLE
Update tests and fix Travis CI core dump

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+
+[report]
+#show_missing = True
+omit =
+    */tests.py
+    */tests/test_*.py

--- a/tcms/testcases/tests.py
+++ b/tcms/testcases/tests.py
@@ -6,7 +6,6 @@ from django.forms import ValidationError
 
 from fields import MultipleEmailField
 from tcms.testcases.models import TestCaseBugSystem
-from tcms.testcases.models import TestCasePlan
 from tcms.tests import BasePlanCase
 from tcms.tests.factories import ComponentFactory
 from tcms.tests.factories import TestBuildFactory
@@ -69,21 +68,14 @@ class TestCaseRemoveBug(BasePlanCase):
     """Test TestCase.remove_bug"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRemoveBug, cls).setUpClass()
+    def setUpTestData(cls):
+        super(TestCaseRemoveBug, cls).setUpTestData()
         cls.build = TestBuildFactory(product=cls.product)
         cls.test_run = TestRunFactory(product_version=cls.version, plan=cls.plan,
                                       manager=cls.tester, default_tester=cls.tester)
         cls.case_run = TestCaseRunFactory(assignee=cls.tester, tested_by=cls.tester,
                                           case=cls.case, run=cls.test_run, build=cls.build)
         cls.bug_system = TestCaseBugSystem.objects.get(name='Bugzilla')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.case_run.delete()
-        cls.test_run.delete()
-        cls.build.delete()
-        super(TestCaseRemoveBug, cls).tearDownClass()
 
     def setUp(self):
         self.bug_id_1 = '12345678'
@@ -142,8 +134,8 @@ class TestCaseRemoveComponent(BasePlanCase):
     """Test TestCase.remove_component"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRemoveComponent, cls).setUpClass()
+    def setUpTestData(cls):
+        super(TestCaseRemoveComponent, cls).setUpTestData()
 
         cls.component_1 = ComponentFactory(name='Application',
                                            product=cls.product,
@@ -156,14 +148,6 @@ class TestCaseRemoveComponent(BasePlanCase):
 
         cls.cc_rel_1 = TestCaseComponentFactory(case=cls.case, component=cls.component_1)
         cls.cc_rel_2 = TestCaseComponentFactory(case=cls.case, component=cls.component_2)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.cc_rel_1.delete()
-        cls.cc_rel_2.delete()
-        cls.component_1.delete()
-        cls.component_2.delete()
-        super(TestCaseRemoveComponent, cls).tearDownClass()
 
     def test_remove_a_component(self):
         self.case.remove_component(self.component_1)
@@ -181,17 +165,11 @@ class TestCaseRemovePlan(BasePlanCase):
     """Test TestCase.remove_plan"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRemovePlan, cls).setUpClass()
+    def setUpTestData(cls):
+        super(TestCaseRemovePlan, cls).setUpTestData()
 
         cls.new_case = TestCaseFactory(author=cls.tester, default_tester=None, reviewer=cls.tester,
                                        plan=[cls.plan])
-
-    @classmethod
-    def tearDownClass(cls):
-        TestCasePlan.objects.filter(plan=cls.plan, case=cls.new_case).delete()
-        cls.new_case.delete()
-        super(TestCaseRemovePlan, cls).tearDownClass()
 
     def test_remove_plan(self):
         self.new_case.remove_plan(self.plan)
@@ -206,20 +184,13 @@ class TestCaseRemoveTag(BasePlanCase):
     """Test TestCase.remove_tag"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRemoveTag, cls).setUpClass()
+    def setUpTestData(cls):
+        super(TestCaseRemoveTag, cls).setUpTestData()
 
         cls.tag_rhel = TestTagFactory(name='rhel')
         cls.tag_fedora = TestTagFactory(name='fedora')
         TestCaseTagFactory(case=cls.case, tag=cls.tag_rhel, user=cls.tester.pk)
         TestCaseTagFactory(case=cls.case, tag=cls.tag_fedora, user=cls.tester.pk)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.case.tag.clear()
-        cls.tag_rhel.delete()
-        cls.tag_fedora.delete()
-        super(TestCaseRemoveTag, cls).tearDownClass()
 
     def test_remove_tag(self):
         self.case.remove_tag(self.tag_rhel)

--- a/tcms/testplans/tests.py
+++ b/tcms/testplans/tests.py
@@ -22,7 +22,7 @@ from tcms.tests.factories import VersionFactory
 class PlanTests(test.TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory(username='admin', email='admin@example.com')
         cls.user.set_password('admin')
         cls.user.is_superuser = True
@@ -43,15 +43,6 @@ class PlanTests(test.TestCase):
                                         product=cls.product,
                                         type=cls.plan_type)
         cls.plan_id = cls.test_plan.pk
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.c.logout()
-        cls.test_plan.delete()
-        cls.product_version.delete()
-        cls.product.delete()
-        cls.classification.delete()
-        cls.user.delete()
 
     def test_open_plans_search(self):
         location = reverse('tcms.testplans.views.all')

--- a/tcms/testruns/tests.py
+++ b/tcms/testruns/tests.py
@@ -20,8 +20,8 @@ class TestOrderCases(BasePlanCase):
     """Test view method order_case"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestOrderCases, cls).setUpClass()
+    def setUpTestData(cls):
+        super(TestOrderCases, cls).setUpTestData()
         cls.build = TestBuildFactory(product=cls.product)
         cls.test_run = TestRunFactory(product_version=cls.version, plan=cls.plan,
                                       manager=cls.tester, default_tester=cls.tester)
@@ -34,18 +34,7 @@ class TestOrderCases(BasePlanCase):
         cls.case_run_3 = TestCaseRunFactory(assignee=cls.tester, tested_by=cls.tester,
                                             run=cls.test_run, case=cls.case_3, build=cls.build,
                                             sortkey=300)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.case_run_1.delete()
-        cls.case_run_2.delete()
-        cls.case_run_3.delete()
-        cls.test_run.delete()
-        cls.build.delete()
-        super(TestOrderCases, cls).tearDownClass()
-
-    def setUp(self):
-        self.client = test.Client()
+        cls.client = test.Client()
 
     def test_404_if_run_does_not_exist(self):
         nonexisting_run_pk = TestRun.objects.count() + 1

--- a/tcms/tests/__init__.py
+++ b/tcms/tests/__init__.py
@@ -13,9 +13,7 @@ class BasePlanCase(test.TestCase):
     """Base test case by providing essential Plan and Case objects used in tests"""
 
     @classmethod
-    def setUpClass(cls):
-        super(BasePlanCase, cls).setUpClass()
-
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='Nitrate')
         cls.version = VersionFactory(value='0.1', product=cls.product)
         cls.tester = UserFactory()
@@ -29,18 +27,3 @@ class BasePlanCase(test.TestCase):
                                      plan=[cls.plan])
         cls.case_3 = TestCaseFactory(author=cls.tester, default_tester=None, reviewer=cls.tester,
                                      plan=[cls.plan])
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.case.plan.clear()
-        cls.case.delete()
-        cls.case_1.delete()
-        cls.case_2.delete()
-        cls.case_3.delete()
-        cls.plan.delete()
-        cls.plan.type.delete()
-        cls.tester.delete()
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        super(BasePlanCase, cls).tearDownClass()

--- a/tcms/xmlrpc/tests/test_product.py
+++ b/tcms/xmlrpc/tests/test_product.py
@@ -12,7 +12,6 @@ from django.test import TestCase
 from tcms.xmlrpc.api import product
 from tcms.xmlrpc.tests.utils import make_http_request
 
-from tcms.management.models import Component
 from tcms.tests.factories import ComponentFactory
 from tcms.tests.factories import ProductFactory
 from tcms.tests.factories import TestBuildFactory
@@ -29,7 +28,7 @@ from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
 class TestCheckCategory(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product_nitrate = ProductFactory(name='nitrate')
         cls.product_xmlrpc = ProductFactory(name='xmlrpc')
         cls.case_categories = [
@@ -37,14 +36,6 @@ class TestCheckCategory(XmlrpcAPIBaseTest):
             TestCaseCategoryFactory(name='manual', product=cls.product_nitrate),
             TestCaseCategoryFactory(name='pending', product=cls.product_xmlrpc),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        [category.delete() for category in cls.case_categories]
-        cls.product_xmlrpc.delete()
-        cls.product_xmlrpc.classification.delete()
-        cls.product_nitrate.delete()
-        cls.product_nitrate.classification.delete()
 
     def test_check_category(self):
         cat = product.check_category(None, 'manual', self.product_nitrate.pk)
@@ -75,7 +66,7 @@ class TestCheckCategory(XmlrpcAPIBaseTest):
 class TestCheckComponent(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product_nitrate = ProductFactory(name='nitrate')
         cls.product_xmlrpc = ProductFactory(name='xmlrpc')
         cls.components = [
@@ -83,15 +74,6 @@ class TestCheckComponent(XmlrpcAPIBaseTest):
             ComponentFactory(name='database', product=cls.product_nitrate),
             ComponentFactory(name='documentation', product=cls.product_xmlrpc),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        for component in cls.components:
-            component.delete()
-        cls.product_nitrate.delete()
-        cls.product_nitrate.classification.delete()
-        cls.product_xmlrpc.delete()
-        cls.product_xmlrpc.classification.delete()
 
     def test_check_component(self):
         cat = product.check_component(None, 'application', self.product_nitrate.pk)
@@ -123,13 +105,8 @@ class TestCheckComponent(XmlrpcAPIBaseTest):
 class TestCheckProduct(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='Nitrate')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_check_product(self):
         cat = product.check_product(None, 'Nitrate')
@@ -148,16 +125,9 @@ class TestCheckProduct(XmlrpcAPIBaseTest):
 class TestFilter(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='Nitrate')
         cls.product_xmlrpc = ProductFactory(name='XMLRPC API')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.product_xmlrpc.delete()
-        cls.product_xmlrpc.classification.delete()
 
     def test_filter_by_id(self):
         prod = product.filter(None, {"id": self.product.pk})
@@ -177,19 +147,12 @@ class TestFilter(XmlrpcAPIBaseTest):
 class TestFilterCategories(TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='Nitrate')
         cls.categories = [
             TestCaseCategoryFactory(name='auto', product=cls.product),
             TestCaseCategoryFactory(name='manual', product=cls.product),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        for category in cls.categories:
-            category.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_filter_by_product_id(self):
         cat = product.filter_categories(None, {'product': self.product.pk})
@@ -207,16 +170,10 @@ class TestFilterCategories(TestCase):
 class TestFilterComponents(TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.component = ComponentFactory(name='application', product=cls.product,
                                          initial_owner=None, initial_qa_contact=None)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.component.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_filter_by_product_id(self):
         com = product.filter_components(None, {'product': self.product.pk})
@@ -232,15 +189,9 @@ class TestFilterComponents(TestCase):
 class TestFilterVersions(TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.version = VersionFactory(value='0.7', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_filter_by_version_id(self):
         ver = product.filter_versions(None, {'id': self.version.pk})
@@ -262,13 +213,8 @@ class TestFilterVersions(TestCase):
 class TestGet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_product(self):
         cat = product.get(None, self.product.pk)
@@ -287,17 +233,10 @@ class TestGet(XmlrpcAPIBaseTest):
 class TestGetBuilds(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.builds_count = 3
         cls.builds = [TestBuildFactory(product=cls.product) for i in range(cls.builds_count)]
-
-    @classmethod
-    def tearDownClass(cls):
-        for build in cls.builds:
-            build.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_build_with_id(self):
         builds = product.get_builds(None, self.product.pk)
@@ -325,7 +264,7 @@ class TestGetBuilds(XmlrpcAPIBaseTest):
 class TestGetCases(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.tester = UserFactory(username='great tester')
         cls.product = ProductFactory(name='StarCraft')
         cls.version = VersionFactory(value='0.1', product=cls.product)
@@ -339,16 +278,6 @@ class TestGetCases(XmlrpcAPIBaseTest):
                                      reviewer=cls.tester, default_tester=None,
                                      plan=[cls.plan])
                      for i in range(cls.cases_count)]
-
-    @classmethod
-    def tearDownClass(cls):
-        for case in cls.cases:
-            case.delete()
-        cls.plan.delete()
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.tester.delete()
 
     def test_get_case_with_id(self):
         cases = product.get_cases(None, self.product.pk)
@@ -374,17 +303,10 @@ class TestGetCases(XmlrpcAPIBaseTest):
 class TestGetCategories(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.category_auto = TestCaseCategoryFactory(name='auto', product=cls.product)
         cls.category_manual = TestCaseCategoryFactory(name='manual', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.category_auto.delete()
-        cls.category_manual.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_categories_with_product_id(self):
         cats = product.get_categories(None, self.product.pk)
@@ -416,15 +338,9 @@ class TestGetCategories(XmlrpcAPIBaseTest):
 class TestGetCategory(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.category = TestCaseCategoryFactory(name='manual', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.category.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_category(self):
         cat = product.get_category(None, self.category.pk)
@@ -443,7 +359,7 @@ class TestGetCategory(XmlrpcAPIBaseTest):
 class TestAddComponent(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.staff = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin, user_perm='management.add_component')
@@ -452,14 +368,6 @@ class TestAddComponent(XmlrpcAPIBaseTest):
 
         # Any added component in tests will be added to this list and then remove them all
         cls.components_to_delete = []
-
-    @classmethod
-    def tearDownClass(cls):
-        Component.objects.filter(pk__in=cls.components_to_delete).delete()
-        cls.staff.delete()
-        cls.admin.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_add_component(self):
         com = product.add_component(self.admin_request, self.product.pk, "application")
@@ -480,15 +388,9 @@ class TestAddComponent(XmlrpcAPIBaseTest):
 class TestGetComponent(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.component = ComponentFactory(name='application', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.component.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_component(self):
         com = product.get_component(None, self.component.pk)
@@ -507,7 +409,7 @@ class TestGetComponent(XmlrpcAPIBaseTest):
 class TestUpdateComponent(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.staff = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin,
@@ -517,14 +419,6 @@ class TestUpdateComponent(XmlrpcAPIBaseTest):
         cls.product = ProductFactory(name='StarCraft')
         cls.component = ComponentFactory(name="application", product=cls.product,
                                          initial_owner=None, initial_qa_contact=None)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.component.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.staff.delete()
-        cls.admin.delete()
 
     def test_update_component(self):
         values = {'name': 'Updated'}
@@ -562,7 +456,7 @@ class TestUpdateComponent(XmlrpcAPIBaseTest):
 class TestGetComponents(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='StarCraft')
         cls.starcraft_version_0_1 = VersionFactory(value='0.1', product=cls.product)
         cls.components = [
@@ -573,13 +467,6 @@ class TestGetComponents(XmlrpcAPIBaseTest):
             ComponentFactory(name='documentation', product=cls.product,
                              initial_owner=None, initial_qa_contact=None),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        [component.delete() for component in cls.components]
-        cls.starcraft_version_0_1.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_components_with_id(self):
         coms = product.get_components(None, self.product.pk)
@@ -627,7 +514,7 @@ class TestGetMilestones(TestCase):
 class TestGetPlans(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory(username='jack')
         cls.product_starcraft = ProductFactory(name='StarCraft')
         cls.starcraft_version_0_1 = VersionFactory(value='0.1', product=cls.product_starcraft)
@@ -646,18 +533,6 @@ class TestGetPlans(XmlrpcAPIBaseTest):
                             product_version=cls.streetfighter_version_0_1,
                             author=cls.user, owner=cls.user),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        [plan.delete() for plan in cls.plans]
-        cls.starcraft_version_0_1.delete()
-        cls.starcraft_version_0_2.delete()
-        cls.streetfighter_version_0_1.delete()
-        cls.product_starcraft.delete()
-        cls.product_starcraft.classification.delete()
-        cls.product_streetfighter.delete()
-        cls.product_streetfighter.classification.delete()
-        cls.user.delete()
 
     def test_get_plans_with_id(self):
         plans = product.get_plans(None, self.product_starcraft.pk)
@@ -687,7 +562,7 @@ class TestGetPlans(XmlrpcAPIBaseTest):
 class TestGetRuns(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.manager = UserFactory(username='manager')
         cls.product = ProductFactory(name='StarCraft')
         cls.build = TestBuildFactory(product=cls.product)
@@ -697,14 +572,6 @@ class TestGetRuns(XmlrpcAPIBaseTest):
             TestRunFactory(summary='Test run for StarCraft: second one',
                            manager=cls.manager, build=cls.build, default_tester=None),
         ]
-
-    @classmethod
-    def tearDownClass(cls):
-        [run.delete() for run in cls.runs]
-        cls.build.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.manager.delete()
 
     def test_get_runs_with_id(self):
         runs = product.get_runs(None, self.product.pk)
@@ -738,12 +605,8 @@ class TestGetRuns(XmlrpcAPIBaseTest):
 class TestGetTag(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.tag = TestTagFactory(name='QWER')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.tag.delete()
 
     def test_get_tag(self):
         tag = product.get_tag(None, self.tag.pk)
@@ -765,20 +628,13 @@ class TestGetTag(XmlrpcAPIBaseTest):
 class TestAddVersion(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product_name = 'StarCraft'
         cls.product = ProductFactory(name=cls.product_name)
         cls.admin = UserFactory(username='tcr_admin', email='tcr_admin@example.com')
         cls.staff = UserFactory(username='tcr_staff', email='tcr_staff@example.com')
         cls.admin_request = make_http_request(user=cls.admin, user_perm='management.add_version')
         cls.staff_request = make_http_request(user=cls.staff)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.admin.delete()
-        cls.staff.delete()
 
     def test_add_version_with_no_args(self):
         self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version, self.admin_request, None)
@@ -832,19 +688,13 @@ class TestAddVersion(XmlrpcAPIBaseTest):
 class TestGetVersions(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product_name = 'StarCraft'
         cls.versions = ['0.6', '0.7', '0.8', '0.9', '1.0']
 
         cls.product = ProductFactory(name=cls.product_name)
         cls.product_versions = [VersionFactory(product=cls.product, value=version)
                                 for version in cls.versions]
-
-    @classmethod
-    def tearDownClass(cls):
-        [version.delete() for version in cls.product_versions]
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_get_versions_with_id(self):
         prod = product.get_versions(None, self.product.pk)

--- a/tcms/xmlrpc/tests/test_serializer.py
+++ b/tcms/xmlrpc/tests/test_serializer.py
@@ -23,10 +23,11 @@ from tcms.tests.factories import TestAttachmentFactory
 
 class TestXMLSerializer(test.TestCase):
 
-    def setUp(self):
-        self.testcase = TestCaseFactory(component=[ComponentFactory(),
-                                                   ComponentFactory(),
-                                                   ComponentFactory()])
+    @classmethod
+    def setUpTestData(cls):
+        cls.testcase = TestCaseFactory(component=[ComponentFactory(),
+                                                  ComponentFactory(),
+                                                  ComponentFactory()])
 
     def test_serializer(self):
         serializer = XMLRPCSerializer(model=self.testcase)
@@ -109,7 +110,7 @@ class TestQuerySetBasedSerializer(test.TestCase):
     '''Test QuerySetBasedXMLRPCSerializer'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.case_author = UserFactory()
 
         cls.plans = [
@@ -139,16 +140,6 @@ class TestQuerySetBasedSerializer(test.TestCase):
         cls.products = [ProductFactory(), ProductFactory(), ProductFactory()]
         cls.products = Product.objects.filter(pk__in=[product.pk for product in cls.products])
         cls.product_serializer = MockProductSerializer(Product, cls.products)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.products.delete()
-        cls.cases.delete()
-        for plan in cls.plans:
-            plan.attachment.all().delete()
-            plan.case.all().delete()
-        cls.plans.delete()
-        cls.case_author.delete()
 
     def test_get_values_fields_mapping(self):
         mapping = self.product_serializer._get_values_fields_mapping()

--- a/tcms/xmlrpc/tests/test_tag.py
+++ b/tcms/xmlrpc/tests/test_tag.py
@@ -10,18 +10,13 @@ from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
 class TestTag(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.tag_db = TestTagFactory(name='db')
         cls.tag_fedora = TestTagFactory(name='fedora')
         cls.tag_python = TestTagFactory(name='python')
         cls.tag_tests = TestTagFactory(name='tests')
         cls.tag_xmlrpc = TestTagFactory(name='xmlrpc')
         cls.tags = [cls.tag_db, cls.tag_fedora, cls.tag_python, cls.tag_tests, cls.tag_xmlrpc]
-
-    @classmethod
-    def tearDownClass(cls):
-        for t in cls.tags:
-            t.delete()
 
     def test_get_tags_with_no_args(self):
         self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, None)

--- a/tcms/xmlrpc/tests/test_testbuild.py
+++ b/tcms/xmlrpc/tests/test_testbuild.py
@@ -22,8 +22,7 @@ from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
 class TestBuildCreate(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestBuildCreate, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin, user_perm='management.add_testbuild')
 
@@ -112,8 +111,7 @@ class TestBuildCreate(XmlrpcAPIBaseTest):
 class TestBuildUpdate(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestBuildUpdate, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin, user_perm='management.change_testbuild')
 
@@ -123,23 +121,9 @@ class TestBuildUpdate(XmlrpcAPIBaseTest):
         cls.product = ProductFactory()
         cls.another_product = ProductFactory()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.another_product.delete()
-        cls.another_product.classification.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        super(TestBuildUpdate, cls).tearDownClass()
-
-    def setUp(self):
-        self.build_1 = TestBuildFactory(product=self.product)
-        self.build_2 = TestBuildFactory(product=self.product)
-        self.build_3 = TestBuildFactory(product=self.product)
-
-    def tearDown(self):
-        self.build_1.delete()
-        self.build_2.delete()
-        self.build_3.delete()
+        cls.build_1 = TestBuildFactory(product=cls.product)
+        cls.build_2 = TestBuildFactory(product=cls.product)
+        cls.build_3 = TestBuildFactory(product=cls.product)
 
     @unittest.skip('TODO: fix update to make this test pass.')
     def test_build_update_with_no_args(self):
@@ -190,16 +174,9 @@ class TestBuildUpdate(XmlrpcAPIBaseTest):
 class TestBuildGet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestBuildGet, cls).setUpClass()
+    def setUpTestData(cls):
         cls.product = ProductFactory()
         cls.build = TestBuildFactory(description='for testing', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.build.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     @unittest.skip('TODO: fix get to make this test pass.')
     def test_build_get_with_no_args(self):
@@ -229,22 +206,12 @@ class TestBuildGet(XmlrpcAPIBaseTest):
 class TestBuildGetCaseRuns(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestBuildGetCaseRuns, cls).setUpClass()
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='Nitrate')
         cls.build = TestBuildFactory(product=cls.product)
         cls.user = UserFactory()
         cls.case_run_1 = TestCaseRunFactory(assignee=cls.user, build=cls.build)
         cls.case_run_2 = TestCaseRunFactory(assignee=cls.user, build=cls.build)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.case_run_1.delete()
-        cls.case_run_2.delete()
-        cls.user.delete()
-        cls.build.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     @unittest.skip('TODO: fix get_caseruns to make this test pass.')
     def test_build_get_with_no_args(self):
@@ -271,22 +238,13 @@ class TestBuildGetCaseRuns(XmlrpcAPIBaseTest):
 class TestBuildGetRuns(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory()
         cls.version = VersionFactory(value='0.1', product=cls.product)
         cls.build = TestBuildFactory(product=cls.product)
         cls.user = UserFactory()
         cls.test_run = TestRunFactory(manager=cls.user, default_tester=None,
                                       build=cls.build)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.test_run.delete()
-        cls.user.delete()
-        cls.build.delete()
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
 
     @unittest.skip('TODO: fix get_runs to make this test pass.')
     def test_build_get_with_no_args(self):
@@ -323,17 +281,9 @@ class TestBuildLookupName(TestCase):
 class TestBuildCheck(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestBuildCheck, cls).setUpClass()
+    def setUpTestData(cls):
         cls.product = ProductFactory()
         cls.build = TestBuildFactory(description='testing ...', product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.build.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        super(TestBuildCheck, cls).tearDownClass()
 
     @unittest.skip('TODO: fix check_build to make this test pass.')
     def test_build_get_with_no_args(self):

--- a/tcms/xmlrpc/tests/test_testcase.py
+++ b/tcms/xmlrpc/tests/test_testcase.py
@@ -18,9 +18,7 @@ class TestNotificationRemoveCC(test.TestCase):
     """ Tests the XMLRPM testcase.notication_remove_cc method """
 
     @classmethod
-    def setUpClass(cls):
-        super(TestNotificationRemoveCC, cls).setUpClass()
-
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
         perm_name = 'testcases.change_testcase'
@@ -29,13 +27,6 @@ class TestNotificationRemoveCC(test.TestCase):
         cls.default_cc = 'example@MrSenko.com'
         cls.testcase = TestCaseFactory()
         cls.testcase.emailing.add_cc(cls.default_cc)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.testcase.emailing.cc_list.all().delete()
-        cls.testcase.delete()
-        cls.user.delete()
-        super(TestNotificationRemoveCC, cls).tearDownClass()
 
     def test_remove_existing_cc(self):
         # initially testcase has the default CC listed

--- a/tcms/xmlrpc/tests/test_testcaseplan.py
+++ b/tcms/xmlrpc/tests/test_testcaseplan.py
@@ -15,8 +15,7 @@ from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
 class TestCasePlanGet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCasePlanGet, cls).setUpClass()
+    def setUpTestData(cls):
         cls.case = TestCaseFactory(summary='test caseplan')
         cls.plan = TestPlanFactory(name='test xmlrpc')
         cls.case_plan = TestCasePlanFactory(case=cls.case, plan=cls.plan)
@@ -63,8 +62,7 @@ class TestCasePlanGet(XmlrpcAPIBaseTest):
 class TestCasePlanUpdate(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCasePlanUpdate, cls).setUpClass()
+    def setUpTestData(cls):
         cls.case = TestCaseFactory(summary='test caseplan')
         cls.plan = TestPlanFactory(name='test xmlrpc')
         cls.case_plan = TestCasePlanFactory(case=cls.case, plan=cls.plan)

--- a/tcms/xmlrpc/tests/test_testcaserun.py
+++ b/tcms/xmlrpc/tests/test_testcaserun.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 from tcms.xmlrpc.api import testcaserun
 from tcms.xmlrpc.tests.utils import make_http_request
-from tcms.testruns.models import TestCaseRun
 from tcms.testruns.models import TestCaseRunStatus
 from tcms.testcases.models import TestCaseBugSystem
 
@@ -29,8 +28,7 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
     """Test testcaserun.create"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunCreate, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory(username='tcr_admin', email='tcr_admin@example.com')
         cls.staff = UserFactory(username='tcr_staff', email='tcr_staff@example.com')
         cls.admin_request = make_http_request(user=cls.admin, user_perm='testruns.add_testcaserun')
@@ -45,22 +43,6 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
         cls.case = TestCaseFactory(author=cls.admin, default_tester=None, plan=[cls.plan])
 
         cls.case_run_pks = []
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestCaseRunCreate, cls).tearDownClass()
-        TestCaseRun.objects.filter(pk__in=cls.case_run_pks).delete()
-        cls.test_run.delete()
-        cls.case.plan.clear()
-        cls.case.delete()
-        cls.plan.delete()
-        cls.plan.type.delete()
-        cls.version.delete()
-        cls.product.build.all().delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.admin.delete()
-        cls.staff.delete()
 
     def test_create_with_no_args(self):
         bad_args = (None, [], {}, (), 1, 0, -1, True, False, '', 'aaaa', object)
@@ -207,8 +189,7 @@ class TestCaseRunAddComment(XmlrpcAPIBaseTest):
     """Test testcaserun.add_comment"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunAddComment, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory(username='update_admin', email='update_admin@example.com')
         cls.admin_request = make_http_request(user=cls.admin,
                                               user_perm='testruns.change_testcaserun')
@@ -250,8 +231,7 @@ class TestCaseRunAttachBug(XmlrpcAPIBaseTest):
     """Test testcaserun.attach_bug"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunAttachBug, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory(username='update_admin', email='update_admin@example.com')
         cls.staff = UserFactory(username='update_staff', email='update_staff@example.com')
         cls.admin_request = make_http_request(user=cls.admin,
@@ -355,8 +335,7 @@ class TestCaseRunAttachLog(XmlrpcAPIBaseTest):
     """Test testcaserun.attach_log"""
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunAttachLog, cls).setUpClass()
+    def setUpTestData(cls):
         cls.case_run = TestCaseRunFactory()
 
     @unittest.skip('TODO: not implemented yet.')
@@ -415,8 +394,7 @@ class TestCaseRunCheckStatus(XmlrpcAPIBaseTest):
 class TestCaseRunDetachBug(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunDetachBug, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.staff = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin,
@@ -493,8 +471,7 @@ class TestCaseRunDetachBug(XmlrpcAPIBaseTest):
 class TestCaseRunDetachLog(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunDetachLog, cls).setUpClass()
+    def setUpTestData(cls):
         cls.status_idle = TestCaseRunStatus.objects.get(name='IDLE')
         cls.tester = UserFactory()
         cls.case_run = TestCaseRunFactory(assignee=cls.tester, tested_by=None,
@@ -555,8 +532,7 @@ class TestCaseRunFilterCount(XmlrpcAPIBaseTest):
 class TestCaseRunGet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGet, cls).setUpClass()
+    def setUpTestData(cls):
         cls.status_idle = TestCaseRunStatus.objects.get(name='IDLE')
         cls.tester = UserFactory()
         cls.case_run = TestCaseRunFactory(assignee=cls.tester, tested_by=None,
@@ -595,8 +571,7 @@ class TestCaseRunGet(XmlrpcAPIBaseTest):
 class TestCaseRunGetSet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGetSet, cls).setUpClass()
+    def setUpTestData(cls):
         cls.status_idle = TestCaseRunStatus.objects.get(name='IDLE')
         cls.tester = UserFactory()
         cls.case_run = TestCaseRunFactory(assignee=cls.tester, tested_by=None,
@@ -663,8 +638,7 @@ class TestCaseRunGetSet(XmlrpcAPIBaseTest):
 class TestCaseRunGetBugs(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGetBugs, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.admin_request = make_http_request(user=cls.admin,
                                               user_perm='testcases.add_testcasebug')
@@ -706,8 +680,7 @@ class TestCaseRunGetBugs(XmlrpcAPIBaseTest):
 class TestCaseRunGetBugsSet(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGetBugsSet, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory(username='update_admin', email='update_admin@example.com')
         cls.admin_request = make_http_request(user=cls.admin,
                                               user_perm='testcases.add_testcasebug')
@@ -801,8 +774,7 @@ class TestCaseRunGetBugsSet(XmlrpcAPIBaseTest):
 class TestCaseRunGetStatus(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGetStatus, cls).setUpClass()
+    def setUpTestData(cls):
         cls.status_running = TestCaseRunStatus.objects.get(name='RUNNING')
 
     def test_get_all_status(self):
@@ -877,8 +849,7 @@ class TestCaseRunGetHistorySet(XmlrpcAPIBaseTest):
 class TestCaseRunGetLogs(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunGetLogs, cls).setUpClass()
+    def setUpTestData(cls):
         cls.case_run_1 = TestCaseRunFactory()
         cls.case_run_2 = TestCaseRunFactory()
         testcaserun.attach_log(None, cls.case_run_1.pk, "Test logs", "http://www.google.com")
@@ -915,8 +886,7 @@ class TestCaseRunGetLogs(XmlrpcAPIBaseTest):
 class TestCaseRunUpdate(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestCaseRunUpdate, cls).setUpClass()
+    def setUpTestData(cls):
         cls.admin = UserFactory()
         cls.staff = UserFactory()
         cls.user = UserFactory()

--- a/tcms/xmlrpc/tests/test_testplan.py
+++ b/tcms/xmlrpc/tests/test_testplan.py
@@ -56,8 +56,7 @@ __all__ = (
 class TestFilter(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestFilter, cls).setUpClass()
+    def setUpTestData(cls):
         cls.product = ProductFactory()
         cls.version = VersionFactory(product=cls.product)
         cls.tester = UserFactory()
@@ -79,20 +78,6 @@ class TestFilter(XmlrpcAPIBaseTest):
                                      reviewer=cls.tester,
                                      plan=[cls.plan_1])
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.plan_1.case.clear()
-        cls.plan_2.case.clear()
-        cls.case_1.delete()
-        cls.case_2.delete()
-        cls.plan_1.delete()
-        cls.plan_2.delete()
-        cls.plan_type.delete()
-        cls.tester.delete()
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-
     def test_filter_plans(self):
         plans = XmlrpcTestPlan.filter(None, {'pk__in': [self.plan_1.pk, self.plan_2.pk]})
         plan = plans[0]
@@ -113,7 +98,7 @@ class TestFilter(XmlrpcAPIBaseTest):
 class TestAddTag(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
         user_should_have_perm(cls.http_req.user, 'testplans.add_testplantag')
@@ -127,17 +112,6 @@ class TestAddTag(XmlrpcAPIBaseTest):
         cls.tag1 = TestTagFactory(name='xmlrpc_test_tag_1')
         cls.tag2 = TestTagFactory(name='xmlrpc_test_tag_2')
         cls.tag_name = 'xmlrpc_tag_name_1'
-
-    @classmethod
-    def tearDownClass(cls):
-        for plan in cls.plans:
-            plan.tag.clear()
-            plan.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.tag1.delete()
-        cls.tag2.delete()
-        cls.user.delete()
 
     def test_single_id(self):
         '''Test with singal plan id and tag id'''
@@ -165,7 +139,7 @@ class TestAddTag(XmlrpcAPIBaseTest):
 class TestAddComponent(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
         perm_name = 'testplans.add_testplancomponent'
@@ -186,17 +160,6 @@ class TestAddComponent(XmlrpcAPIBaseTest):
                                           product=cls.product,
                                           initial_owner=None,
                                           initial_qa_contact=None)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.component1.delete()
-        cls.component2.delete()
-        for plan in cls.plans:
-            plan.component.clear()
-            plan.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.user.delete()
 
     def test_single_id(self):
         XmlrpcTestPlan.add_component(self.http_req, self.plans[0].pk, self.component1.pk)
@@ -220,13 +183,9 @@ class TestAddComponent(XmlrpcAPIBaseTest):
 class TestPlanTypeMethods(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.http_req = make_http_request()
         cls.plan_type = TestPlanTypeFactory(name='xmlrpc plan type', description='')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.plan_type.delete()
 
     def test_check_plan_type(self):
         self.assertRaisesXmlrpcFault(BAD_REQUEST, XmlrpcTestPlan.check_plan_type, self.http_req)
@@ -249,18 +208,11 @@ class TestPlanTypeMethods(XmlrpcAPIBaseTest):
 class TestGetProduct(XmlrpcAPIBaseTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.http_req = make_http_request()
         cls.user = UserFactory()
         cls.product = ProductFactory()
         cls.plan = TestPlanFactory(author=cls.user, owner=cls.user, product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.plan.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.user.delete()
 
     def _verify_serialize_result(self, result):
         self.assertEqual(self.plan.product.name, result['name'])
@@ -300,7 +252,7 @@ class TestGetTestCases(XmlrpcAPIBaseTest):
     '''Test testplan.get_test_cases method'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.http_req = make_http_request()
 
         cls.tester = UserFactory(username='tester')
@@ -316,17 +268,6 @@ class TestGetTestCases(XmlrpcAPIBaseTest):
                             plan=[cls.plan]),
         ]
         cls.another_plan = TestPlanFactory(author=cls.tester, owner=cls.tester, product=cls.product)
-
-    @classmethod
-    def tearDownClass(cls):
-        for case in cls.cases:
-            case.plan.clear()
-            case.delete()
-        cls.plan.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.reviewer.delete()
-        cls.tester.delete()
 
     def test_get_test_cases(self):
         serialized_cases = XmlrpcTestPlan.get_test_cases(self.http_req, self.plan.pk)
@@ -381,9 +322,7 @@ class TestUpdate(test.TestCase):
     """ Tests the XMLRPM testplan.update method """
 
     @classmethod
-    def setUpClass(cls):
-        super(TestUpdate, cls).setUpClass()
-
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
         perm_name = 'testplans.change_testplan'
@@ -405,20 +344,6 @@ class TestUpdate(test.TestCase):
                                      author=cls.tester,
                                      type=cls.plan_type,
                                      env_group=(cls.env_group_1,))
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.plan_1.delete()
-        cls.plan_2.delete()
-        cls.plan_type.delete()
-        cls.tester.delete()
-        cls.user.delete()
-        cls.version.delete()
-        cls.product.delete()
-        cls.product.classification.delete()
-        cls.env_group_1.delete()
-        cls.env_group_2.delete()
-        super(TestUpdate, cls).tearDownClass()
 
     def test_update_env_group(self):
         # plan_1 and plan_2 point to self.env_group_1
@@ -588,16 +513,12 @@ class TestProcessCase(test.TestCase):
     '''Test process_case'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.xml2dict = XML2Dict()
         cls.user = UserFactory(username='xml user', email='user@example.com')
         cls.priority_p1, created = Priority.objects.get_or_create(value='P1')
         cls.status_confirmed, created = TestCaseStatus.objects.get_or_create(name='CONFIRMED')
         cls.status_proposed, created = TestCaseStatus.objects.get_or_create(name='PROPOSED')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
 
     def _format_xml_case_string(self, case_data):
         """Helper method to format case XML conveniently"""
@@ -690,7 +611,7 @@ class TestCleanXMLFile(test.TestCase):
     '''Test for testplan.clean_xml_file'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory(username='xml user', email='user@example.com')
         cls.priority = Priority.objects.get(value='P1')
         cls.status_confirmed = TestCaseStatus.objects.get(name='CONFIRMED')
@@ -699,12 +620,6 @@ class TestCleanXMLFile(test.TestCase):
         if hasattr(settings, 'TESTOPIA_XML_VERSION'):
             cls.original_xml_version = settings.TESTOPIA_XML_VERSION
         settings.TESTOPIA_XML_VERSION = 1.1
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
-        if cls.original_xml_version is not None:
-            settings.TESTOPIA_XML_VERSION = cls.original_xml_version
 
     def test_clean_xml_file(self):
         result = clean_xml_file(xml_file_without_error)

--- a/tcms/xmlrpc/tests/test_user.py
+++ b/tcms/xmlrpc/tests/test_user.py
@@ -18,9 +18,10 @@ from tcms.xmlrpc.tests.utils import XmlrpcAPIBaseTest
 class TestUserSerializer(TestCase):
     '''Test User.get_user_dict'''
 
-    def setUp(self):
-        self.user = UserFactory()
-        self.http_req = make_http_request(user=self.user)
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        cls.http_req = make_http_request(user=cls.user)
 
     def test_ensure_password_not_returned(self):
         data = XUser.get_user_dict(self.user)
@@ -33,7 +34,7 @@ class TestUserFilter(TestCase):
     '''Test User.filter'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.group_tester = GroupFactory(name='tester')
         cls.group_reviewer = GroupFactory(name='reviewer')
 
@@ -45,17 +46,6 @@ class TestUserFilter(TestCase):
                                 groups=[cls.group_reviewer])
 
         cls.http_req = make_http_request()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user1.groups.clear()
-        cls.user2.groups.clear()
-        cls.user3.groups.clear()
-        cls.group_tester.delete()
-        cls.group_reviewer.delete()
-        cls.user1.delete()
-        cls.user2.delete()
-        cls.user3.delete()
 
     def test_normal_search(self):
         users = XUser.filter(self.http_req, {'email': 'user2@example.com'})
@@ -80,13 +70,9 @@ class TestUserGet(XmlrpcAPIBaseTest):
     '''Test User.get'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
 
     def test_get(self):
         test_user = self.http_req.user
@@ -106,13 +92,9 @@ class TestUserGetMe(TestCase):
     '''Test User.get_me'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory()
         cls.http_req = make_http_request(user=cls.user)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
 
     def test_get_me(self):
         test_user = self.http_req.user
@@ -125,18 +107,12 @@ class TestUserJoin(XmlrpcAPIBaseTest):
     '''Test User.join'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.http_req = make_http_request(user_perm='auth.change_user')
         cls.username = 'test_username'
         cls.user = UserFactory(username=cls.username, email='username@example.com')
         cls.group_name = 'test_group'
         cls.group = GroupFactory(name=cls.group_name)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.groups.clear()
-        cls.group.delete()
-        cls.user.delete()
 
     def test_join_normally(self):
         XUser.join(self.http_req, self.username, self.group_name)
@@ -158,7 +134,7 @@ class TestUserUpdate(XmlrpcAPIBaseTest):
     '''Test User.update'''
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.user = UserFactory(username='bob', email='bob@example.com')
         cls.user.set_password(cls.user.username)
         cls.user.save()
@@ -171,11 +147,6 @@ class TestUserUpdate(XmlrpcAPIBaseTest):
             'last_name': 'new last name',
             'email': 'new email',
         }
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.user.delete()
-        cls.another_user.delete()
 
     def test_update_myself(self):
         data = XUser.update(self.http_req,

--- a/tcms/xmlrpc/tests/test_utils.py
+++ b/tcms/xmlrpc/tests/test_utils.py
@@ -31,13 +31,8 @@ class TestParseBool(unittest.TestCase):
 class TestPreCheckProduct(test.TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.product = ProductFactory(name='World Of Warcraft')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.product.delete()
-        cls.product.classification.delete()
 
     def test_pre_check_product_with_dict(self):
         product = U.pre_check_product({"product": self.product.pk})


### PR DESCRIPTION
This is a fix for #161 which removes `tearDownClass` and replaces `setUpClass` with `setUpTestData` which appears to be the recommended Django way since 1.8. It also magically fixes the core dumps in Travis CI. 

The second commit instructs coverage report to omit test files in the report and reveals we have 40% actual code coverage :(