### PR TITLE
Enable testing with MySQL and Postgres on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.7"
@@ -9,10 +10,24 @@ services:
   - mysql
   - postgresql
 addons:
-  - postgresql: '9.5'
+  - postgresql: 9.5
+matrix:
+  include:
+    - python: 2.7
+      env: TEST_DB=MariaDB
+      addons:
+        mariadb: 10.1
 before_install:
+  - cat "$TRAVIS_BUILD_DIR/.travis/my.cnf" | sudo tee -a /etc/mysql/conf.d/mariadb.cnf
+  - sudo cat /etc/mysql/conf.d/mariadb.cnf
+  - sudo service mysql restart
+
   - mysql -e 'SELECT VERSION();'
-  - mysql -e 'CREATE DATABASE nitrate_travis CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+  - mysql -e 'CREATE DATABASE nitrate_travis CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
+  - mysql -e 'GRANT ALL PRIVILEGES ON nitrate_travis.* TO travis;'
+  - mysql -e 'CREATE DATABASE test_nitrate_travis CHARACTER SET utf8 COLLATE utf8_unicode_ci;' 
+  - mysql -e 'GRANT ALL PRIVILEGES ON test_nitrate_travis.* TO travis;'
+
   - psql -c  "CREATE DATABASE nitrate_travis ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U postgres
   - pip install coveralls psycopg2
 install: "pip install -r requirements/devel.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,19 @@ before_install:
   - sudo service mysql restart
 
   - mysql -e 'SELECT VERSION();'
-  - mysql -e 'CREATE DATABASE nitrate_travis CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
-  - mysql -e 'GRANT ALL PRIVILEGES ON nitrate_travis.* TO travis;'
-  - mysql -e 'CREATE DATABASE test_nitrate_travis CHARACTER SET utf8 COLLATE utf8_unicode_ci;' 
-  - mysql -e 'GRANT ALL PRIVILEGES ON test_nitrate_travis.* TO travis;'
+  - mysql -e 'CREATE USER "nitrate" IDENTIFIED BY "";'
+  - mysql -e 'CREATE DATABASE nitrate CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
+  - mysql -e 'GRANT ALL PRIVILEGES ON nitrate.* TO nitrate;'
+  - mysql -e 'CREATE DATABASE test_nitrate CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
+  - mysql -e 'GRANT ALL PRIVILEGES ON test_nitrate.* TO nitrate;'
 
-  - psql -c  "CREATE DATABASE nitrate_travis ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U postgres
-  - pip install coveralls psycopg2
-install: "pip install -r requirements/devel.txt"
+  - psql -c  "CREATE DATABASE nitrate ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U postgres
+install:
+  - export REQUIREMENTS_TXT="requirements/$(echo $TEST_DB | tr '[:upper:]' '[:lower:]' | sed 's/mariadb/mysql/' | sed 's/sqlite/base/').txt"
+  - echo "REQUIREMENTS_TXT=$REQUIREMENTS_TXT"
+  - pip install -r $REQUIREMENTS_TXT
+  - pip install -r requirements/devel.txt
+  - pip install coveralls
 script: make check
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: python
 python:
   - "2.7"
+env:
+  - TEST_DB=SQLite
+  - TEST_DB=MySQL
+  - TEST_DB=Postgres
+services:
+  - mysql
+  - postgresql
+addons:
+  - postgresql: '9.5'
 before_install:
-  - pip install coveralls
+  - mysql -e 'SELECT VERSION();'
+  - mysql -e 'CREATE DATABASE nitrate_travis CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+  - psql -c  "CREATE DATABASE nitrate_travis ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8';" -U postgres
+  - pip install coveralls psycopg2
 install: "pip install -r requirements/devel.txt"
 script: make check
 after_success:

--- a/.travis/my.cnf
+++ b/.travis/my.cnf
@@ -1,0 +1,11 @@
+[client]
+default-character-set=utf8
+
+[mysql]
+default-character-set=utf8
+
+[mysqld]
+character-set-server = utf8
+character_set_server = utf8
+collation-server = utf8_unicode_ci
+collation_server = utf8_unicode_ci

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,30 @@ else
 	TEST_TARGET=$(strip (TEST_TARGET))
 endif
 
+DJANGO_SETTINGS_MODULE="tcms.settings.test"
+
+ifeq ($(TEST_DB),MySQL)
+	DJANGO_SETTINGS_MODULE="tcms.settings.test.mysql"
+endif
+
+ifeq ($(TEST_DB),MariaDB)
+	DJANGO_SETTINGS_MODULE="tcms.settings.test.mysql"
+endif
+
+ifeq ($(TEST_DB),Postgres)
+	DJANGO_SETTINGS_MODULE="tcms.settings.test.postgresql"
+endif
+
+
 .PHONY: test
 test:
-	@pytest $(TEST_TARGET)
+	if [ "$$TEST_DB" == "all" ]; then \
+		for DB in SQLite MySQL Postgres MariaDB; do \
+			TEST_DB=$$DB make test; \
+		done; \
+	else \
+		DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pytest $(TEST_TARGET); \
+	fi
 
 
 .PHONY: check

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -17,7 +17,7 @@ A brief history
 Dependencies
 ------------
 
-Basic dependences::
+Basic dependences (excluding database engine)::
 
     Python >= 2.6.5
 
@@ -26,4 +26,3 @@ Basic dependences::
 Additional recommended dependences for development:
 
 .. literalinclude:: ../../requirements/devel.txt
-

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -20,6 +20,21 @@ on. Once you find a problem, please search it in the `Issues`_ to see whether
 it has been reported by other people. If no one reported there yet, you are
 encouraged to file one with detailed and descriptive description.
 
+Automated test suite can be execute with the ``make test`` command. The
+following syntax is supported::
+
+        make test (uses SQlite)
+        TEST_DB=MySQL make test
+        TEST_DB=MariaDB make test
+        TEST_DB=Postgres make test
+        TEST_DB=all make test (will test on all DBs)
+
+.. note::
+
+    If you want to execute testing against different DB engines on your local
+    development environment make sure the respecitve DB engines are installed
+    and configured! ``make test`` uses the configuration files under
+    ``tcms/settings/test/``. Make sure to edit them if necessary!
 
 Documentation
 -------------

--- a/docs/source/installing_in_rhel.rst
+++ b/docs/source/installing_in_rhel.rst
@@ -34,9 +34,13 @@ Install devel packages that should be installed first::
 
     sudo yum install gcc w3m python-devel mysql-devel krb5-devel libxml2-devel libxslt-devel
 
-Install dependencies from ``requirements/base.txt``::
+Install dependencies from ``requirements/mysql.txt``::
 
-    sudo pip install -r requirements/base.txt
+    sudo pip install -r requirements/mysql.txt
+
+.. note::
+
+    Alternatively you can use ``requirements/postgres.txt`` for PostgreSQL!
 
 Install from source code
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/installing_in_virtualenv.rst
+++ b/docs/source/installing_in_virtualenv.rst
@@ -42,13 +42,17 @@ dependencies. See :doc:`set_dev_env` for more information. Then::
     (venv)# git clone https://github.com/Nitrate/Nitrate.git
     (venv)# cd ./Nitrate/
     (venv)# git checkout --track [a proper tag or branch]
-    (venv)# pip install -r ./requirements/base.txt
+    (venv)# pip install -r ./requirements/mysql.txt
     (venv)# python setup.py install
 
 .. note::
 
     Nitrate source code has been cloned into your home directory but
     has been installed into the virtual environment for Apache!
+
+.. note::
+
+    Alternatively you can use ``requirements/postgres.txt`` for PostgreSQL!
 
 
 Initialize database

--- a/docs/source/set_dev_env.rst
+++ b/docs/source/set_dev_env.rst
@@ -21,16 +21,21 @@ Create a virtual environment for Nitrate::
 
     virtualenv ~/virtualenvs/nitrate
 
-Install dependencies from ``requirements/devel.txt``::
+Install dependencies for development::
 
     . ~/virtualenvs/nitrate/bin/activate
+    pip install -r requirements/mysql.txt
     pip install -r requirements/devel.txt
+
+.. note::
+
+    Alternatively you can use ``requirements/postgres.txt`` for PostgreSQL!
 
 Initialize database
 -------------------
 
-Currently, MySQL is only be supported, either mysql or mariadb is okay for
-running Nitrate.
+Currently we recommend either MySQL or MariaDB for running Nitrate. Support
+for PostgreSQL is still experimental.
 
 Create database and user::
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 Django==1.8.14
-MySQL-python==1.2.5
 kerberos==1.1.1
 qpid-python==0.20
 django-uuslug==1.1.8

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -1,4 +1,3 @@
--r base.txt
 django-debug-toolbar==1.4
 Sphinx>=1.1.2
 flake8

--- a/requirements/mysql.txt
+++ b/requirements/mysql.txt
@@ -1,0 +1,2 @@
+-r base.txt
+MySQL-python==1.2.5

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,0 +1,2 @@
+-r base.txt
+psycopg2

--- a/tcms/core/models/fields.py
+++ b/tcms/core/models/fields.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-from MySQLdb.constants import FIELD_TYPE
+try:
+    # Nitrate may not be running under MySQL
+    from MySQLdb.constants import FIELD_TYPE
+    from django.db.backends.mysql.base import django_conversions
+    django_conversions.update({FIELD_TYPE.TIME: None})
+except ImportError:
+    pass
+
 from django.conf import settings
 from django.db.models.fields import IntegerField
 from django.db import models
-from django.db.backends.mysql.base import django_conversions
 
 from tcms.core.forms.fields import DurationField as DurationFormField
-
-django_conversions.update({FIELD_TYPE.TIME: None})
 
 
 class BlobValueWrapper(object):

--- a/tcms/settings/test.py
+++ b/tcms/settings/test.py
@@ -1,15 +1,32 @@
+import os
 from tcms.settings.devel import *
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': '',
+        'NAME': ':memory:',
         'USER': '',
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
     }
 }
+
+if 'TRAVIS' in os.environ:
+    if os.environ.get('TEST_DB').lower() in ['mysql', 'mariadb']:
+        DATABASES['default'].update({
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'nitrate_travis',
+            'USER': 'travis',
+            'HOST': '127.0.0.1',
+        })
+    elif os.environ.get('TEST_DB').lower() == 'postgres':
+        DATABASES['default'].update({
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'nitrate_travis',
+            'USER': 'postgres',
+            'HOST': 'localhost',
+        })
 
 LISTENING_MODEL_SIGNAL = False
 

--- a/tcms/settings/test/__init__.py
+++ b/tcms/settings/test/__init__.py
@@ -1,4 +1,3 @@
-import os
 from tcms.settings.devel import *
 
 DATABASES = {
@@ -11,22 +10,6 @@ DATABASES = {
         'PORT': '',
     }
 }
-
-if 'TRAVIS' in os.environ:
-    if os.environ.get('TEST_DB').lower() in ['mysql', 'mariadb']:
-        DATABASES['default'].update({
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'nitrate_travis',
-            'USER': 'travis',
-            'HOST': '127.0.0.1',
-        })
-    elif os.environ.get('TEST_DB').lower() == 'postgres':
-        DATABASES['default'].update({
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'nitrate_travis',
-            'USER': 'postgres',
-            'HOST': 'localhost',
-        })
 
 LISTENING_MODEL_SIGNAL = False
 

--- a/tcms/settings/test/mysql.py
+++ b/tcms/settings/test/mysql.py
@@ -1,0 +1,9 @@
+from tcms.settings.test import *
+
+DATABASES['default'].update({
+    'ENGINE': 'django.db.backends.mysql',
+    'NAME': 'nitrate',
+    'USER': 'nitrate',
+    'PASSWORD': '',
+    'HOST': '127.0.0.1',
+})

--- a/tcms/settings/test/postgresql.py
+++ b/tcms/settings/test/postgresql.py
@@ -1,0 +1,8 @@
+from tcms.settings.test import *
+
+DATABASES['default'].update({
+    'ENGINE': 'django.db.backends.postgresql_psycopg2',
+    'NAME': 'nitrate',
+    'USER': 'postgres',
+    'HOST': 'localhost',
+})

--- a/tcms/testruns/tests.py
+++ b/tcms/testruns/tests.py
@@ -37,7 +37,7 @@ class TestOrderCases(BasePlanCase):
         cls.client = test.Client()
 
     def test_404_if_run_does_not_exist(self):
-        nonexisting_run_pk = TestRun.objects.count() + 1
+        nonexisting_run_pk = TestRun.objects.last().pk + 1
         url = reverse('tcms.testruns.views.order_case', args=[nonexisting_run_pk])
         response = self.client.get(url)
         self.assertEqual(httplib.NOT_FOUND, response.status_code)


### PR DESCRIPTION
This PR enables MySQL and Postgres on Travis. I have a support ticket opened with their team to figure out how to add MariaDB alongside MySQL.

The build will fail b/c there are some issue with both MySQL and Postgres. I will try to fix them in subsequent commits.