### PR TITLE
Fix tags search and hint while adding tags to test cases in TP

### DIFF
--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -47,12 +47,15 @@ def check_permission(request, ctype):
     return False
 
 
-def strip_parameters(request, skip_parameters):
+def strip_parameters(request_dict, skip_parameters):
+    """
+    Helper method which will remove the dict items listed in skip_parameters
+    @return - dict
+    """
     parameters = {}
-    for dict_ in request.REQUEST.dicts:
-        for k, v in dict_.items():
-            if k not in skip_parameters and v:
-                parameters[str(k)] = v
+    for k, v in request_dict.items():
+        if k not in skip_parameters and v:
+            parameters[str(k)] = v
 
     return parameters
 
@@ -120,7 +123,7 @@ def info(request):
             )
 
         def tags(self):
-            query = strip_parameters(request, self.internal_parameters)
+            query = strip_parameters(request.GET, self.internal_parameters)
             tags = TestCaseTag.objects
             # Generate the string combination, because we are using
             # case sensitive table
@@ -137,7 +140,7 @@ def info(request):
         def users(self):
             from django.contrib.auth.models import User
 
-            query = strip_parameters(self.request, self.internal_parameters)
+            query = strip_parameters(self.request.GET, self.internal_parameters)
             return User.objects.filter(**query)
 
         def versions(self):
@@ -172,7 +175,7 @@ def form(request):
 
     # The parameters in internal_parameters will delete from parameters
     internal_parameters = ['app_form', 'format']
-    parameters = strip_parameters(request, internal_parameters)
+    parameters = strip_parameters(request.REQUEST, internal_parameters)
     q_app_form = request.REQUEST.get('app_form')
     q_format = request.REQUEST.get('format')
     if not q_format:

--- a/tcms/core/tests/test_ajax.py
+++ b/tcms/core/tests/test_ajax.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from tcms.core.ajax import strip_parameters
+
+
+class Test_strip_parameters(unittest.TestCase):
+    def setUp(self):
+        self.request_dict = {
+            'name__startswith': 'something',
+            'info_type': 'tags',
+            'format': 'ulli',
+            'case__plan': 1,
+            'field': 'tag__name',
+        }
+        self.internal_parameters = ('info_type', 'field', 'format')
+
+    def test_remove_parameters_in_dict(self):
+        simplified_dict = strip_parameters(self.request_dict, self.internal_parameters)
+        for p in self.internal_parameters:
+            self.assertFalse(p in simplified_dict)
+
+        self.assertEqual('something', simplified_dict['name__startswith'])
+        self.assertEqual(1, simplified_dict['case__plan'])
+
+    def test_remove_parameters_not_in_dict(self):
+        simplified_dict = strip_parameters(self.request_dict, ['non-existing-parameter'])
+        self.assertEqual(self.request_dict, simplified_dict)

--- a/tcms/static/js/testplan_actions.js
+++ b/tcms/static/js/testplan_actions.js
@@ -2468,8 +2468,8 @@ function constructBatchTagProcessDialog(plan_id) {
           'name__startswith': request.term,
           'info_type': 'tags',
           'format': 'ulli',
-          'testcase__plan__pk': plan_id,
-          'field': 'name'
+          'case__plan': plan_id,
+          'field': 'tag__name'
         },
         'success': function(data) {
           var processedData = [];

--- a/tcms/templates/plan/get_cases.html
+++ b/tcms/templates/plan/get_cases.html
@@ -231,7 +231,7 @@
 		</form>
 	</script>
 	<script id="batch_tag_summary_template" type="text/x-handlebars-template">
-		<div class="dia_title" style=" margin:10px 20px;">You have successfully operate tags in the following case:</div>
+		<div class="dia_title" style=" margin:10px 20px;">You have successfully updated tags for the following case(s):</div>
 		<div class="dialog_content">
 			{{# each tags }}
 			<div class="dia_content" style=" margin:10px 20px;">{{ this.pk }} &nbsp; {{ this.fields.summary }}</div>


### PR DESCRIPTION
How to reproduce:
- Open a Test Plan
- Go to Cases tab
- Select few test cases
- click Tag -> Add Tag button
- start typing tag name
- if there are tags which match the text they will be shown
  ad a drop-down hint. This was previously raising an exception.

Also simplified the strip_parameters() function which is
used internally and made minor updates to the template and
JavaScript files to match the backend changes and model field names.

Note:
Removal of tags bug is #174 which is fixed in PR #177
