### PR TITLE
Build Nitrate as docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM centos/httpd
+
+# install virtualenv and libraries needed to build the python dependencies
+RUN yum -y --setopt=tsflags=nodocs install python-virtualenv gcc mariadb-devel \
+    krb5-devel libxml2-devel libxslt-devel git mod_wsgi
+# enable when you want to update RPM packages
+# this will be used for testing building a Docker image with the
+# latest possible versions from CentOS!
+#RUN yum -y update --setopt=tsflags=nodocs
+RUN yum clean all
+
+# static files configuration for Apache
+COPY ./contrib/conf/nitrate-httpd.conf /etc/httpd/conf.d/
+
+# configure uploads directory
+RUN mkdir -p /var/nitrate/uploads
+RUN chown apache:apache /var/nitrate/uploads
+
+# Create a virtualenv for the application dependencies
+# Using --system-site-packages b/c Apache configuration
+# expects the tcms directory to be there!
+RUN virtualenv --system-site-packages /venv
+
+# Set virtualenv environment variables. This is equivalent to running
+# source /env/bin/activate. This ensures the application is executed within
+# the context of the virtualenv and will have access to its dependencies.
+ENV VIRTUAL_ENV /venv
+ENV PATH /venv/bin:$PATH
+
+
+# Install Nitrate dependencies
+COPY ./requirements/ /Nitrate/requirements/
+RUN pip install -r /Nitrate/requirements/base.txt
+
+# Add manage.py
+COPY ./manage.py /Nitrate/
+RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" /Nitrate/manage.py
+
+# Add application code
+COPY ./tcms/ /usr/lib/python2.7/site-packages/tcms/
+RUN find /usr/lib/python2.7/site-packages/tcms/ -name "*.pyc" -delete
+
+# collect static files
+RUN /Nitrate/manage.py collectstatic --noinput

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,18 @@ etags:
 	@ctags -R -e --languages=Python,CSS,Javascript --python-kinds=-im \
 		--exclude=build --exclude=tcms/static/js/lib -f TAGS
 
+ifeq ($(DOCKER_ORG),)
+  DOCKER_ORG='nitrate'
+endif
+
+NITRATE_VERSION=$(shell cat tcms/__init__.py | grep __version__ | cut -f2 -d"'")
+
+docker-image:
+	docker build -t $(DOCKER_ORG)/nitrate:$(NITRATE_VERSION) .
+
+docker-run: docker-image
+	docker compose up
+
 
 .PHONY: help
 help:

--- a/contrib/conf/nitrate-httpd.conf
+++ b/contrib/conf/nitrate-httpd.conf
@@ -10,9 +10,6 @@
 #    RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI}
 #</IfModule>
 
-# Make sure static files collected to this dir
-# Ref https://docs.djangoproject.com/en/1.5/ref/contrib/staticfiles/#django-admin-collectstatic
-Alias /static /usr/share/nitrate/static
 
 # Limit threads forked:
 # prefork MPM 
@@ -23,8 +20,9 @@ MaxClients 256
 MaxRequestsPerChild 0
 
 # Configurations for mod_wsgi
-WSGIScriptAlias / /usr/lib/python2.6/site-packages/tcms/wsgi.py
-WSGIPythonPath /usr/lib/python2.6/site-packages
+WSGIDaemonProcess nitrateapp python-path=/venv/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
+WSGIProcessGroup nitrateapp
+WSGIScriptAlias / /usr/lib/python2.7/site-packages/tcms/wsgi.py
 WSGIPassAuthorization On
 
 <Location "/">
@@ -34,7 +32,6 @@ WSGIPassAuthorization On
     SetHandler wsgi-script
 
     Options All
-    AllowOverride All
     Require all granted
     LimitRequestBody 10485760
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/javascript application/x-javascript text/css
@@ -42,8 +39,12 @@ WSGIPassAuthorization On
     ErrorDocument 401 "Your request is unauthorization."
 </Location>
 
+# Make sure static files are collected to this dir
+Alias /static /usr/share/nitrate/static
+
 <Location "/static">
     SetHandler None
+    Options -Indexes
 
     # Disable auth on the static content, so that we're aren't forced to
     # use Kerberos.  Doing so would remove "Expires" headers from the static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+    db:
+        image: centos/mariadb
+        volumes:
+            - nitrate_db_data:/var/lib/mysql
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: nitrate-1s-aw3s0m3
+            MYSQL_DATABASE: nitrate
+            MYSQL_USER: nitrate
+            MYSQL_PASSWORD: nitrate
+
+    web:
+        depends_on:
+            - db
+        restart: always
+        image: nitrate/nitrate:3.8.18
+        ports:
+            - 80
+        volumes:
+            - nitrate_uploads:/var/nitrate/uploads
+        environment:
+            NITRATE_DB_HOST: db
+            NITRATE_DB_PORT: 3306
+            NITRATE_DB_NAME: nitrate
+            NITRATE_DB_USER: nitrate
+            NITRATE_DB_PASSWORD: nitrate
+
+volumes:
+    nitrate_db_data:
+    nitrate_uploads:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents
    about.rst
    set_dev_env.rst
    set_dev_env_with_vagrant.rst
+   installing_docker.rst
    installing_in_rhel.rst
    installing_in_virtualenv.rst
    installing_gunicorn.rst

--- a/docs/source/installing_docker.rst
+++ b/docs/source/installing_docker.rst
@@ -1,0 +1,57 @@
+Running Nitrate as a Docker container
+=====================================
+
+Build Docker image
+------------------
+
+You can build a Docker image of Nitrate by running::
+
+    make docker-image
+
+This will create a Docker image based on the official CentOS 7 image
+with the latest Nitrate. By default the image tag will be
+``nitrate/nitrate:<version>``.
+
+
+Create Docker container
+-----------------------
+
+You can then start using Nitrate by executing::
+
+    docker-compose up -d
+
+
+This will create two containers:
+
+1) A web container based on the latest Nitrate image
+2) A DB container based on the official centos/mariadb image
+
+
+``docker-compose`` will also create two volumes for persistent data storage:
+``nitrate_db_data`` and ``nitrate_uploads``.
+
+
+Initial configuration of running container
+------------------------------------------
+
+You need to do initial configuration by executing::
+
+    docker exec -it nitrate_web_1 /Nitrate/manage.py migrate
+    docker exec -it nitrate_web_1 /Nitrate/manage.py createsuperuser
+
+Upgrading
+---------
+
+To upgrade running Nitrate containers execute the following commands::
+
+    git pull
+    make docker-image
+    docker-compose stop
+    docker rm nitrate_web_1 nitrate_db_1
+    docker-compose up -d
+    docker exec -it nitrate_web_1 /Nitrate/manage.py migrate
+
+.. note::
+    Uploads and database data should stay intact because they are split into
+    separate volumes, which makes upgrading very easy. However you may want to
+    back these up before upgrading!

--- a/tcms/settings/product.py
+++ b/tcms/settings/product.py
@@ -1,5 +1,6 @@
 # Django settings for product env.
 
+import os
 from common import *
 
 # Debug settings
@@ -10,19 +11,19 @@ TEMPLATE_DEBUG = DEBUG
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'nitrate',
-        'USER': 'nitrate',
-        'PASSWORD': 'nitrate',
-        'HOST': '',
-        'PORT': '',
+        'NAME': os.environ.get('NITRATE_DB_NAME', 'nitrate'),
+        'USER': os.environ.get('NITRATE_DB_USER', 'nitrate'),
+        'PASSWORD': os.environ.get('NITRATE_DB_PASSWORD', 'nitrate'),
+        'HOST': os.environ.get('NITRATE_DB_HOST', ''),
+        'PORT': os.environ.get('NITRATE_DB_PORT', ''),
     },
     'slave_1': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'nitrate',
-        'USER': 'nitrate',
-        'PASSWORD': 'nitrate',
-        'HOST': '',
-        'PORT': '',
+        'NAME': os.environ.get('NITRATE_DB_NAME', 'nitrate'),
+        'USER': os.environ.get('NITRATE_DB_USER', 'nitrate'),
+        'PASSWORD': os.environ.get('NITRATE_DB_PASSWORD', 'nitrate'),
+        'HOST': os.environ.get('NITRATE_DB_HOST', ''),
+        'PORT': os.environ.get('NITRATE_DB_PORT', ''),
     },
 }
 


### PR DESCRIPTION
This PR makes it possible to build Nitrate as a Docker image and adds a docker compose to be able to execute the web app and the DB app together as 2 different containers. It also adds persistent volumes for upload storage and database data, which makes upgrades very easy. Also adds documentation. 

Notes: 
1) Once this is merged I intend to make use of it and create integration tests with Python+Selenium and have them run as part of the Travis CI build
2) The documentation part about running Nitrate into Google cloud engine (which uses Docker images) will need to be updated but I have to re-test into GCE with the new image first. This can be done in a stand alone PR
3) We really need to decide which would be the recommended way to install and run Nitrate and clean up the docs a little bit. There are too many options which are kind of confusing, OTOH I really have no idea how everyone feels about running Docker containers inside their environment. I guess people wouldn't mind so we can designate Docker to be the official way of consuming Nitrate from now on.