### PR TITLE
Hide Errata field if ERRATA_URL_PREFIX not set. Fix #186

### DIFF
--- a/tcms/templates/run/edit.html
+++ b/tcms/templates/run/edit.html
@@ -70,10 +70,12 @@
 					{{ form.build }} 
 					<a href="{{ ADMIN_PREFIX }}/management/testbuild/add/" class="addlink" id="add_id_build">Add Build</a></td>
 			</tr>
+                        {% if errata_url_prefix %}
 			<tr>
 				<td><label>Errata </label></td>
 				<td>{{ form.errata_id }}</td>
 			</tr>
+                        {% endif %}
 			<tr>
 				<td><label>Manager</label></td>
 				{% ifequal test_run.manager user %}

--- a/tcms/templates/run/get.html
+++ b/tcms/templates/run/get.html
@@ -147,14 +147,14 @@ jQ(function() {
 					<a href="{% url "tcms.testruns.views.all" %}?build={{ test_run.build_id }}" title="Search test runs of {{ test_run.build_id }}">{{ test_run.build }}</a>
 				</div>
 			</div>
+                        {% if errata_url_prefix and test_run.errata_id %}
 			<div class="listinfo">
 				<div class="title grey">Errata&nbsp;:</div>
 				<div class="name">
-				{% if test_run.errata_id %}
 				<a href="{{ errata_url_prefix }}/{{ test_run.errata_id }}" target="_blank">{{ test_run.errata_id }}</a>
-				{% endif %}
 				</div>
 			</div>
+                        {% endif %}
 			<div class="listinfo">
 				<div class="title grey">Default Tester&nbsp;:</div>
 				<div class="name">

--- a/tcms/templates/run/new.html
+++ b/tcms/templates/run/new.html
@@ -69,10 +69,12 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 						<a href="{{ ADMIN_PREFIX }}/management/testbuild/add/" class="addlink" id="add_id_build">Add Build</a>
 					</td>
 				</tr>
+                                {% if errata_url_prefix %}
 				<tr>
 					<td valign="top"><label for="id_errata_id">Errata</label></td>
 					<td>{{ form.errata_id }}<div class="errors">{{ form.errata_id.errors }}</div></td>
 				</tr>
+                                {% endif %}
 				<tr>
 					<td valign="top" valign="top"><label for="id_manager">Run Manager </label></td>
 					<td valign="top">{{ form.manager }}<div class="errors">{{ form.manager.errors }}</div></td>

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -230,6 +230,7 @@ def new(request, template_name='run/new.html'):
         'form': form,
         'num_unconfirmed_cases': num_unconfirmed_cases,
         'run_estimated_time': estimated_time,
+        'errata_url_prefix': settings.ERRATA_URL_PREFIX,
     }
     return render_to_response(template_name, context_data,
                               context_instance=RequestContext(request))
@@ -852,6 +853,7 @@ def edit(request, run_id, template_name='run/edit.html'):
         'sub_module': SUB_MODULE_NAME,
         'test_run': tr,
         'form': form,
+        'errata_url_prefix': settings.ERRATA_URL_PREFIX,
     }
     return render_to_response(template_name, context_data,
                               context_instance=RequestContext(request))


### PR DESCRIPTION
This fixes the obvious problem: if the setting is not set don't ever show the related fields so we don't confuse the user.