### PR TITLE
Remove clean_request() b/c not used

### DIFF
--- a/tcms/core/utils/__init__.py
+++ b/tcms/core/utils/__init__.py
@@ -56,28 +56,6 @@ def request_host_link(request, domain_name=None):
     return protocol + domain_name
 
 
-def clean_request(request, keys=None):
-    """
-    Clean the request strings
-    """
-    request_contents = request.REQUEST.copy()
-    if not keys:
-        keys = request_contents.keys()
-    rt = {}
-    for k in keys:
-        k = str(k)
-        if request_contents.get(k):
-            if k == 'order_by' or k == 'from_plan':
-                continue
-
-            v = request.REQUEST[k]
-            # Convert the value to be list if it's __in filter.
-            if k.endswith('__in') and isinstance(v, unicode):
-                v = string_to_list(v)
-            rt[k] = v
-    return rt
-
-
 class QuerySetIterationProxy(object):
     '''Iterate a series of object and its associated objects at once
 

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -32,7 +32,6 @@ from tcms.core.db import SQLExecution
 from tcms.core.exceptions import NitrateException
 from tcms.core.responses import HttpJSONResponse
 from tcms.core.utils.bugtrackers import Bugzilla
-from tcms.core.utils import clean_request
 from tcms.core.utils.raw_sql import RawSQL
 from tcms.core.utils.tcms_router import connection
 from tcms.core.utils.timedeltaformat import format_timedelta
@@ -665,15 +664,7 @@ def open_run_get_case_runs(request, run):
     tcrs = tcrs.extra(select={
         'num_bug': RawSQL.num_case_run_bugs,
     })
-    tcrs = tcrs.distinct()
-    # Continue to search the case runs with conditions
-    # 4. case runs preparing for render case runs table
-    tcrs = tcrs.filter(**clean_request(request))
-    order_by = request.REQUEST.get('order_by')
-    if order_by:
-        tcrs = tcrs.order_by(order_by)
-    else:
-        tcrs = tcrs.order_by('sortkey', 'pk')
+    tcrs = tcrs.distinct().order_by('sortkey', 'pk')
     return tcrs
 
 


### PR DESCRIPTION
clean_request() is only used inside
testruns/views.py:open_run_get_case_runs() which in turn is only
used inside testruns/views.py:get(), which renders a particular
test run. E.g. /run/4/.

As far as I understand we could pass query string (GET) parameters
when viewing a TR via its URL. For example
http://127.0.0.1:8000/run/4/?order_by=case__summary to order cases
by their summary, not by sortkey/pk.

From what I can tell nowhere in Nitrate we use the functionality
to load a TR so that it's cases are sorted differently other than
by sortkey.

Original discussion from 
https://github.com/Nitrate/Nitrate/pull/176#pullrequestreview-32227624
