### PR TITLE
Upgrade kerberos to 1.2.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==1.8.14
 MySQL-python==1.2.5
-kerberos==1.1.1
+kerberos==1.2.5
 qpid-python==0.20
 django-uuslug==1.1.8
 django-celery>=3.1.10


### PR DESCRIPTION
Support both Python 2 and 3.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>