### PR TITLE
Refactor datatable response

### DIFF
--- a/tcms/core/utils/__init__.py
+++ b/tcms/core/utils/__init__.py
@@ -132,3 +132,60 @@ class QuerySetIterationProxy(object):
                         getattr(next_one, self._associate_name, None),
                         ()))
         return next_one
+
+
+class DataTableResult(object):
+    """Paginate and order queryset for rendering DataTable response"""
+
+    DEFAULT_PAGE_SIZE = 20
+
+    def __init__(self, request_data, queryset, column_names):
+        self.queryset = queryset
+        self.request_data = request_data
+        self.column_names = column_names
+
+    def _iter_sorting_columns(self):
+        number_of_sorting_cols = int(self.request_data.get('iSortingCols', 0))
+        for idx_which_column in range(number_of_sorting_cols):
+            sorting_col_index = int(
+                self.request_data.get('iSortCol_{}'.format(idx_which_column),
+                                      0))
+
+            sortable_key = 'bSortable_{}'.format(sorting_col_index)
+            sort_dir_key = 'sSortDir_{}'.format(idx_which_column)
+
+            sortable = self.request_data.get(sortable_key, 'false')
+            if sortable == 'false':
+                continue
+
+            sorting_col_name = self.column_names[sorting_col_index]
+            sorting_direction = self.request_data.get(sort_dir_key, 'asc')
+            yield sorting_col_name, sorting_direction
+
+    def _sort_result(self):
+        sorting_columns = self._iter_sorting_columns()
+        order_fields = ['-{}'.format(col_name) if direction == 'desc' else col_name
+                        for col_name, direction in sorting_columns]
+        if order_fields:
+            self.queryset = self.queryset.order_by(*order_fields)
+
+    def _paginate_result(self):
+        display_length = min(
+            int(self.request_data.get('iDisplayLength', self.DEFAULT_PAGE_SIZE)),
+            100)
+        display_start = int(self.request_data.get('iDisplayStart', 0))
+        display_end = display_start + display_length
+        self.queryset = self.queryset[display_start:display_end]
+
+    def get_response_data(self):
+        total_records = total_display_records = self.queryset.count()
+
+        self._sort_result()
+        self._paginate_result()
+
+        return {
+            'sEcho': int(self.request_data.get('sEcho', 0)),
+            'iTotalRecords': total_records,
+            'iTotalDisplayRecords': total_display_records,
+            'querySet': self.queryset,
+        }

--- a/tcms/templates/plan/common/json_plan_runs.txt
+++ b/tcms/templates/plan/common/json_plan_runs.txt
@@ -3,7 +3,7 @@
 	"iTotalRecords": {{iTotalRecords}},
 	"iTotalDisplayRecords": {{iTotalDisplayRecords}},
 	"aaData": [
-		{% for run in runs %}
+		{% for run in querySet %}
 		[
 			"<input type='checkbox' name='run' value='{{ run.pk }}' class='run_selector'>",
 			"<a href='{% url "tcms.testruns.views.get" run.run_id %}' >{{ run.run_id }}</a>",

--- a/tcms/templates/run/common/json_runs.txt
+++ b/tcms/templates/run/common/json_runs.txt
@@ -3,7 +3,7 @@
 	"iTotalRecords": {{ iTotalRecords }},
 	"iTotalDisplayRecords": {{ iTotalDisplayRecords }},
 	"aaData":[
-	{% for run in runs %}
+	{% for run in querySet %}
 	[
 		"<input type='checkbox' name='run' value='{{  run.pk  }}' class='run_selector'>",
 		"<a href='{% url "tcms.testruns.views.get" run.run_id %}'>{{  run.run_id  }}</a>",

--- a/tcms/testcases/tests.py
+++ b/tcms/testcases/tests.py
@@ -12,6 +12,7 @@ from django import test
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.forms import ValidationError
+from django.test import RequestFactory
 
 from uuslug import slugify
 
@@ -23,6 +24,7 @@ from tcms.testcases.models import TestCaseTag
 from tcms.testcases.models import TestCaseBugSystem
 from tcms.testcases.models import TestCaseComponent
 from tcms.testcases.models import TestCasePlan
+from tcms.testcases.views import ajax_response
 from tcms.tests.factories import ComponentFactory
 from tcms.tests.factories import TestBuildFactory
 from tcms.tests.factories import TestCaseCategoryFactory
@@ -1032,3 +1034,80 @@ class TestSearchCases(BasePlanCase):
                 self.product.pk, self.product.name),
             html=True
         )
+
+
+class TestAJAXResponse(BasePlanCase):
+    """Test ajax_response"""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+        self.column_names = [
+            'case_id',
+            'summary',
+            'author__username',
+            'default_tester__username',
+            'is_automated',
+            'case_status__name',
+            'category__name',
+            'priority__value',
+            'create_date',
+        ]
+
+        self.template = 'case/common/json_cases.txt'
+
+    def test_return_empty_cases(self):
+        url = reverse('tcms.testcases.views.ajax_search')
+        request = self.factory.get(url, {
+
+        })
+        request.user = self.tester
+
+        empty_cases = TestCase.objects.none()
+        response = ajax_response(request, empty_cases, self.column_names, self.template)
+
+        data = json.loads(response.content)
+
+        self.assertEqual(0, data['sEcho'])
+        self.assertEqual(0, data['iTotalRecords'])
+        self.assertEqual(0, data['iTotalDisplayRecords'])
+        self.assertEqual([], data['aaData'])
+
+    def test_return_sorted_cases_by_name_desc(self):
+        url = reverse('tcms.testcases.views.ajax_search')
+        request = self.factory.get(url, {
+            'sEcho': 1,
+            'iDisplayStart': 0,
+            'iDisplayLength': 2,
+            'iSortCol_0': 0,
+            'sSortDir_0': 'desc',
+            'iSortingCols': 1,
+            'bSortable_0': 'true',
+            'bSortable_1': 'true',
+            'bSortable_2': 'true',
+            'bSortable_3': 'true',
+        })
+        request.user = self.tester
+
+        cases = self.plan.case.all()
+        response = ajax_response(request, cases, self.column_names, self.template)
+
+        data = json.loads(response.content)
+
+        total = self.plan.case.count()
+        self.assertEqual(1, data['sEcho'])
+        self.assertEqual(total, data['iTotalRecords'])
+        self.assertEqual(total, data['iTotalDisplayRecords'])
+        self.assertEqual(2, len(data['aaData']))
+
+        id_links = [row[2] for row in data['aaData']]
+        id_links.sort()
+        expected_id_links = [
+            "<a href='{0}'>{1}</a>".format(
+                reverse('tcms.testcases.views.get', args=[case.pk]),
+                case.pk,
+            )
+            for case in self.plan.case.order_by('-pk')[0:2]
+        ]
+        expected_id_links.sort()
+        self.assertEqual(expected_id_links, id_links)

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -23,25 +23,31 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.http import require_GET
 from uuslug import slugify
 
-from tcms.core.views import Prompt
+from tcms.core.db import SQLExecution
+from tcms.core.models import TCMSLog
 from tcms.core.responses import HttpJSONResponse
+from tcms.core.utils.checksum import checksum
+from tcms.core.utils import DataTableResult
 from tcms.core.utils.raw_sql import RawSQL
-from tcms.testcases.models import TestCase, TestCasePlan
-from tcms.testcases.models import TestCaseStatus, TestCaseCategory
+from tcms.core.views import Prompt
 from tcms.management.models import TCMSEnvGroup, Component
+from tcms.search import remove_from_request_path
+from tcms.search.order import order_plan_queryset
+from tcms.testcases.forms import SearchCaseForm, QuickSearchCaseForm
+from tcms.testcases.models import TestCaseStatus, TestCaseCategory
+from tcms.testcases.models import TestCase, TestCasePlan
+from tcms.testcases.views import get_selected_testcases
+from tcms.testplans.forms import ClonePlanForm
+from tcms.testplans.forms import EditPlanForm
+from tcms.testplans.forms import ImportCasesViaXMLForm
+from tcms.testplans.forms import NewPlanForm
+from tcms.testplans.forms import PlanComponentForm
+from tcms.testplans.forms import SearchPlanForm
+from tcms.testplans import sqls
 from tcms.testplans.models import TestPlan, TestPlanComponent
 from tcms.testruns.models import TestRun, TestCaseRun
-from tcms.core.models import TCMSLog
-from tcms.search.order import order_plan_queryset
-from tcms.search import remove_from_request_path
-from tcms.testcases.views import get_selected_testcases
-from tcms.testplans.forms import NewPlanForm, EditPlanForm, ClonePlanForm, \
-    ImportCasesViaXMLForm, SearchPlanForm, PlanComponentForm
-from tcms.core.db import SQLExecution
-from tcms.core.utils.checksum import checksum
-from tcms.testcases.forms import SearchCaseForm, QuickSearchCaseForm
-from tcms.testplans import sqls
 from tcms.utils.dict_utils import create_group_by_dict as create_dict
+
 
 MODULE_NAME = "testplans"
 
@@ -382,114 +388,40 @@ def ajax_search(request, template_name='plan/common/json_plans.txt'):
             else:
                 tps = TestPlan.list(search_form.cleaned_data)
                 tps = tps.select_related('author', 'owner', 'type', 'product')
+
     # columnIndexNameMap is required for correct sorting behavior, 5 should
     # be product, but we use run.build.product
-    columnIndexNameMap = {
-        0: '',
-        1: 'plan_id',
-        2: 'name',
-        3: 'author__username',
-        4: 'owner__username',
-        5: 'product',
-        6: 'product_version',
-        7: 'type',
-        8: 'num_cases',
-        9: 'num_runs',
-        10: ''
-    }
-    return ajax_response(request, tps, columnIndexNameMap,
-                         jsonTemplatePath='plan/common/json_plans.txt')
+    column_names = [
+        '',
+        'plan_id',
+        'name',
+        'author__username',
+        'owner__username',
+        'product',
+        'product_version',
+        'type',
+        'num_cases',
+        'num_runs',
+        ''
+    ]
+    return ajax_response(request, tps, column_names,
+                         'plan/common/json_plans.txt')
 
 
-# TODO: refactor this method by moving sorting, pagination and data calculation
-# to the outside. Response just does what the response is resposible for to the
-# HTTP.
-def ajax_response(request, querySet, columnIndexNameMap,
-                  jsonTemplatePath='plan/common/json_plans.txt', *args):
-    '''
-    json template for the ajax request for searching.
-    '''
-    cols = int(request.GET.get('iColumns', 0))  # Get the number of columns
-    # Safety measure. If someone messes with iDisplayLength manually, we
-    # clip it to the max value of 100.
-    iDisplayLength = min(int(request.GET.get('iDisplayLength', 20)), 100)
-    if iDisplayLength == -1:
-        startRecord = 0
-        endRecord = querySet.count()
-    else:
-        # Where the data starts from (page)
-        startRecord = int(request.GET.get('iDisplayStart', 0))
-        # where the data ends (end of page)
-        endRecord = startRecord + iDisplayLength
-    # Pass sColumns
-    keys = columnIndexNameMap.keys()
-    keys.sort()
-    colitems = [columnIndexNameMap[key] for key in keys]
-    sColumns = ",".join(map(str, colitems))
+def ajax_response(request, queryset, column_names, template_name):
+    """json template for the ajax request for searching"""
+    dt = DataTableResult(request.GET, queryset, column_names)
 
-    # Ordering data
-    iSortingCols = int(request.GET.get('iSortingCols', 0))
-    asortingCols = []
+    data = dt.get_response_data()
+    data['querySet'] = calculate_stats_for_testplans(data['querySet'])
 
-    if iSortingCols:
-        for sortedColIndex in range(0, iSortingCols):
-            sortedColID = int(
-                request.GET.get('iSortCol_' + str(sortedColIndex), 0))
-            # make sure the column is sortable first
-            if request.GET.get('bSortable_%s' % sortedColID, 'false') == \
-                    'true':
-                sortedColName = columnIndexNameMap[sortedColID]
-                sortingDirection = request.GET.get(
-                    'sSortDir_' + str(sortedColIndex), 'asc')
-                if sortingDirection == 'desc':
-                    sortedColName = '-' + sortedColName
-                asortingCols.append(sortedColName)
-        if len(asortingCols):
-            querySet = querySet.order_by(*asortingCols)
-    # count how many records match the final criteria
-    iTotalRecords = iTotalDisplayRecords = querySet.count()
-    # get the slice
-    querySet = querySet[startRecord:endRecord]
-
-    # We need to display the number of cases and runs that are related to each
-    # TestPlan.
-    querySet = calculate_stats_for_testplans(querySet)
-
-    sEcho = int(request.GET.get('sEcho', 0))  # required echo response
-
-    if jsonTemplatePath:
-        try:
-            # prepare the JSON with the response, consider using :
-            # from django.template.defaultfilters import escapejs
-            jsonString = render_to_string(jsonTemplatePath, locals(),
-                                          context_instance=RequestContext(
-                                              request))
-            response = HttpJSONResponse(jsonString)
-        except Exception as e:
-            print e
-    else:
-        aaData = []
-        a = querySet.values()
-        for row in a:
-            rowkeys = row.keys()
-            rowvalues = row.values()
-            rowlist = []
-            for col in range(0, len(colitems)):
-                for idx, val in enumerate(rowkeys):
-                    if val == colitems[col]:
-                        rowlist.append(str(rowvalues[idx]))
-            aaData.append(rowlist)
-            response_dict = {}
-            response_dict.update({'aaData': aaData})
-            response_dict.update(
-                {'sEcho': sEcho, 'iTotalRecords': iTotalRecords,
-                 'iTotalDisplayRecords': iTotalDisplayRecords,
-                 'sColumns': sColumns})
-            response = HttpJSONResponse(json_dumps(response_dict))
-            # prevent from caching datatables result
-            # add_never_cache_headers(response)
-
-    return response
+    # prepare the JSON with the response, consider using :
+    # from django.template.defaultfilters import escapejs
+    json_result = render_to_string(
+        template_name,
+        data,
+        context_instance=RequestContext(request))
+    return HttpJSONResponse(json_result)
 
 
 def get(request, plan_id, slug=None, template_name='plan/get.html'):

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -650,6 +650,33 @@ class TestAJAXSearchRuns(BaseCaseRun):
             default_tester=cls.run_tester,
             tag=[TestTagFactory(name='rhel')])
 
+        cls.search_data = {
+            'action': 'search',
+            # Add criteria for searching runs in each test
+
+            # DataTable properties: pagination and sorting
+            'sEcho': 1,
+            'iDisplayStart': 0,
+            # Make enough length to display all searched runs in one page
+            'iDisplayLength': TestRun.objects.count() + 1,
+            'iSortCol_0': 1,
+            'sSortDir_0': 'asc',
+            'iSortingCols': 1,
+            # In the view, first column is not sortable.
+            'bSortable_0': 'false',
+            'bSortable_1': 'true',
+            'bSortable_2': 'true',
+            'bSortable_3': 'true',
+            'bSortable_4': 'true',
+            'bSortable_5': 'true',
+            'bSortable_6': 'true',
+            'bSortable_7': 'true',
+            'bSortable_8': 'true',
+            'bSortable_9': 'true',
+            'bSortable_10': 'true',
+            'bSortable_11': 'true',
+        }
+
     def assert_found_runs(self, expected_found_runs, search_result):
         expected_runs_count = len(expected_found_runs)
         self.assertEqual(expected_runs_count, search_result['iTotalRecords'])

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -34,6 +34,7 @@ from tcms.core.exceptions import NitrateException
 from tcms.core.responses import HttpJSONResponse
 from tcms.core.utils.bugtrackers import Bugzilla
 from tcms.core.utils import clean_request
+from tcms.core.utils import DataTableResult
 from tcms.core.utils.raw_sql import RawSQL
 from tcms.core.utils.tcms_router import connection
 from tcms.core.utils.timedeltaformat import format_timedelta
@@ -348,18 +349,19 @@ def load_runs_of_one_plan(request, plan_id,
     data, it accepts field lookup parameters collected from the filter panel
     in the UI.
     """
-    column_index_name_map = {0: '',
-                             1: 'run_id',
-                             2: 'summary',
-                             3: 'manager__username',
-                             4: 'default_tester__username',
-                             5: 'start_date',
-                             6: 'build__name',
-                             7: 'stop_date',
-                             8: 'total_num_caseruns',
-                             9: 'failure_caseruns_percent',
-                             10: 'successful_caseruns_percent',
-                             }
+    column_names = {
+        '',
+        'run_id',
+        'summary',
+        'manager__username',
+        'default_tester__username',
+        'start_date',
+        'build__name',
+        'stop_date',
+        'total_num_caseruns',
+        'failure_caseruns_percent',
+        'successful_caseruns_percent',
+    }
 
     tp = TestPlan.objects.get(plan_id=plan_id)
     form = PlanFilterRunForm(request.GET)
@@ -369,10 +371,9 @@ def load_runs_of_one_plan(request, plan_id,
         queryset = queryset.select_related(
             'build', 'manager', 'default_tester').order_by('-pk')
 
-        total_records = total_display_records = queryset.count()
-
-        queryset = sort_queryset(request, queryset, column_index_name_map)
-        queryset = datatable_paginate(request, queryset)
+        dt = DataTableResult(request.GET, queryset, column_names)
+        response_data = dt.get_response_data()
+        searched_runs = response_data['querySet']
 
         # Get associated statistics data
         run_filters = dict(('run__{0}'.format(key), value)
@@ -399,7 +400,7 @@ def load_runs_of_one_plan(request, plan_id,
         cases_subtotal = magic_convert(qs,
                                        key_name='run', value_name='count')
 
-        for run in queryset:
+        for run in searched_runs:
             run_id = run.pk
             cases_count = cases_subtotal.get(run_id, 0)
             if cases_count:
@@ -413,16 +414,15 @@ def load_runs_of_one_plan(request, plan_id,
                 'success_percent': success_percent,
             }
     else:
-        queryset = TestRun.objects.none()
-        total_records = total_display_records = queryset.count()
+        response_data = {
+            'sEcho': int(request.GET.get('sEcho', 0)),
+            'iTotalRecords': 0,
+            'iTotalDisplayRecords': 0,
+            'querySet': TestRun.objects.none(),
+        }
 
-    context = {
-        'sEcho': int(request.GET.get('sEcho', 0)),
-        'iTotalRecords': total_records,
-        'iTotalDisplayRecords': total_display_records,
-        'runs': queryset,
-    }
-    json_data = render_to_string(template_name, context,
+    json_data = render_to_string(template_name,
+                                 response_data,
                                  context_instance=RequestContext(request))
     return HttpJSONResponse(json_data)
 
@@ -430,20 +430,6 @@ def load_runs_of_one_plan(request, plan_id,
 @require_GET
 def ajax_search(request, template_name='run/common/json_runs.txt'):
     """Response request to search test runs from Search Runs"""
-    column_index_name_map = {0: '',
-                             1: 'run_id',
-                             2: 'summary',
-                             3: 'manager__username',
-                             4: 'default_tester__username',
-                             5: 'plan',
-                             6: 'build__product__name',
-                             7: 'product_version',
-                             8: 'env_groups',
-                             9: 'total_num_caseruns',
-                             10: 'stop_date',
-                             11: 'completed',
-                             }
-
     search_form = SearchRunForm(request.GET)
     if request.GET.get('product'):
         search_form.populate(product_id=request.GET['product'])
@@ -457,60 +443,67 @@ def ajax_search(request, template_name='run/common/json_runs.txt'):
             'default_tester',
             'build',
             'plan',
-            'build__product__name').only('run_id',
-                                         'summary',
-                                         'manager__username',
-                                         'default_tester__id',
-                                         'default_tester__username',
-                                         'plan__name',
-                                         'build__product__name',
-                                         'stop_date',
-                                         'product_version__value')
+            'build__product__name'
+        ).only(
+            'run_id',
+            'summary',
+            'manager__username',
+            'default_tester__id',
+            'default_tester__username',
+            'plan__name',
+            'build__product__name',
+            'stop_date',
+            'product_version__value'
+        )
 
         # Further optimize by adding caserun attributes:
         trs = trs.extra(
             select={'env_groups': RawSQL.environment_group_for_run},
         )
 
-        total_records = total_display_records = trs.count()
+        column_names = [
+            '',
+            'run_id',
+            'summary',
+            'manager__username',
+            'default_tester__username',
+            'plan',
+            'build__product__name',
+            'product_version',
+            'env_groups',
+            'total_num_caseruns',
+            'stop_date',
+            'completed',
+        ]
 
-        trs = sort_queryset(request, trs, column_index_name_map)
-        trs = datatable_paginate(request, trs)
+        dt = DataTableResult(request.GET, trs, column_names)
+        response_data = dt.get_response_data()
+        searched_runs = response_data['querySet']
 
         # Get associated statistics data
-        run_ids = [run.pk for run in trs]
+        run_ids = [run.pk for run in searched_runs]
         qs = TestCaseRun.objects \
-            .filter(case_run_status=TestCaseRunStatus.id_failed(),
-                    run__in=run_ids) \
+            .filter(case_run_status=TestCaseRunStatus.id_failed(), run__in=run_ids) \
             .values('run', 'case_run_status') \
             .annotate(count=Count('pk')) \
             .order_by('run', 'case_run_status')
-        failure_subtotal = magic_convert(qs,
-                                         key_name='run',
-                                         value_name='count')
+        failure_subtotal = magic_convert(qs, key_name='run', value_name='count')
 
         completed_status_ids = TestCaseRunStatus._get_completed_status_ids()
         qs = TestCaseRun.objects \
-            .filter(case_run_status__in=completed_status_ids,
-                    run__in=run_ids) \
+            .filter(case_run_status__in=completed_status_ids, run__in=run_ids) \
             .values('run', 'case_run_status') \
             .annotate(count=Count('pk')) \
             .order_by('run', 'case_run_status')
         completed_subtotal = dict((
             (run_id, sum((item['count'] for item in stats_rows)))
             for run_id, stats_rows
-            in itertools.groupby(qs.iterator(),
-                                 key=lambda row: row['run'])))
+            in itertools.groupby(qs.iterator(), key=lambda row: row['run'])))
 
-        qs = TestCaseRun.objects \
-            .filter(run__in=run_ids) \
-            .values('run') \
-            .annotate(cases_count=Count('case'))
-        cases_subtotal = magic_convert(qs,
-                                       key_name='run',
-                                       value_name='cases_count')
+        qs = TestCaseRun.objects.filter(run__in=run_ids).values('run').annotate(cases_count=Count('case'))
+        cases_subtotal = magic_convert(qs, key_name='run', value_name='cases_count')
 
-        for run in trs:
+        for run in searched_runs:
             run_id = run.pk
             cases_count = cases_subtotal.get(run_id, 0)
             if cases_count:
@@ -524,93 +517,17 @@ def ajax_search(request, template_name='run/common/json_runs.txt'):
                 'failure_percent': failure_percent,
             }
     else:
-        trs = TestRun.objects.none()
-        total_records = total_display_records = trs.count()
+        response_data = {
+            'sEcho': int(request.GET.get('sEcho', 0)),
+            'iTotalRecords': 0,
+            'iTotalDisplayRecords': 0,
+            'runs': TestRun.objects.none(),
+        }
 
-    # columnIndexNameMap is required for correct sorting behavior, 5 should
-    # be product, but we use run.build.product
-    context = {
-        'sEcho': int(request.GET.get('sEcho', 0)),
-        'iTotalRecords': total_records,
-        'iTotalDisplayRecords': total_display_records,
-        'runs': trs,
-    }
-    json_data = render_to_string(template_name, context,
+    json_data = render_to_string(template_name,
+                                 response_data,
                                  context_instance=RequestContext(request))
     return HttpJSONResponse(json_data)
-
-
-def datatable_paginate(request, queryset):
-    """Paginate queryset
-
-    DataTable sends request with pagination information that is extracted and
-    used to paginate queried queryset.
-    """
-    DEFAULT_PAGE_SIZE = 10
-    MAX_SIZE_PER_PAGE = 100
-
-    # Safety measure. If someone messes with iDisplayLength manually,
-    # we clip it to the max value of 100.
-    display_length = min(int(request.GET.get('iDisplayLength',
-                                             DEFAULT_PAGE_SIZE)),
-                         MAX_SIZE_PER_PAGE)
-    # Where the data starts from (page)
-    start_record = int(request.GET.get('iDisplayStart', 0))
-    # where the data ends (end of page)
-    end_record = start_record + display_length
-
-    return queryset[start_record:end_record]
-
-
-def get_sorting_cols(request, index_column_name_mapping):
-    """Find sorting column and sort direction for each of them
-
-    This works on top of parameters passed along with HTTP request by
-    DataTable.
-
-    :param HTTPRequest request: request object containing sorting information
-    passed by DataTable.
-    :param dict index_column_name_mapping: a mapping from column index to
-    column name. This is passed by a method that is calling this method.
-    :return: sequence of column names sort on. Sort direction will be prefixed
-    if desc is specified by DataTable. If there is no sorting columns found,
-    an empty sequence is returned, that is safe to pass to QuerySet that will
-    not cause Django to generate ORDER BY clause.
-    :rtype: list
-    """
-    get = request.GET.get
-
-    iSortingCols = int(get('iSortingCols', 0))
-    if not iSortingCols:
-        return []
-
-    mapping = ((int(get('iSortCol_{0}'.format(sorting_col_index))),
-                get('sSortDir_{0}'.format(sorting_col_index)))
-               for sorting_col_index in range(0, iSortingCols)
-               if get('bSortable_{0}'.format(
-                   get('iSortCol_{0}'.format(sorting_col_index)))) == u'true')
-
-    return ['{0}{1}'.format('-' if sSortDir_N == 'desc' else '',
-                            index_column_name_mapping[iSortCol_N])
-            for iSortCol_N, sSortDir_N in mapping]
-
-
-def sort_queryset(request, queryset, index_column_name_mapping):
-    """Sort queryset on specified column by DataTable
-
-    Each time an AJAX request from DataTable to sort on a particular column,
-    a set of variable are sent together within the HTTP request. All of them
-    are used to determine which column queryset is sorted on, which columns are
-    sortable (that is defined by JavaScript code in client side), which
-    direction to sort the column that is ASC or DESC.
-
-    :param dict index_column_name_mapping: a mapping from column index to
-    column name, that is used to find and construct the sequence of columns to
-    sort on and the sort direction. This mapping must be as same as the column
-    definitions in client side.
-    """
-    sorting_cols = get_sorting_cols(request, index_column_name_mapping)
-    return queryset.order_by(*sorting_cols)
 
 
 def open_run_get_case_runs(request, run):


### PR DESCRIPTION
New DataTableResult is introduced to handle search objects pagination
and sorting for generating response data for rendering in DataTable in
user's web browser.

Search plans, cases, runs and runs in plan page are modified to use this
new class.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>