### PR TITLE
Refactor inner action class CaseActions

### DIFF
--- a/tcms/fixtures/cases-to-import.xml
+++ b/tcms/fixtures/cases-to-import.xml
@@ -4,101 +4,101 @@
         <!ENTITY testopia_gt ">">
         ]>
 <testopia version="1.1">
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Remove this case from a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Remove this another case from a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Test link cases to a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Test delete (unlink) cases from a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Remove this case from a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
     <testcase author="admin@example.com"
               priority="P1"
               automated="0"
               status="CONFIRMED">
         <summary>Remove this another case from a test plan</summary>
         <categoryname>--default--</categoryname>
-        
+
         <defaulttester></defaulttester>
         <notes></notes>
         <action></action>
         <expectedresults></expectedresults>
         <setup></setup>
         <breakdown></breakdown>
-        
+
     </testcase>
-    
+
 </testopia>

--- a/tcms/static/js/testplan_actions.js
+++ b/tcms/static/js/testplan_actions.js
@@ -1188,7 +1188,6 @@ function unlinkCasesFromPlan(container, form, table) {
   }
 
   var parameters = serialzeCaseForm(form, table, true);
-  parameters.a = 'delete_cases';
   if (selection.selectAll) {
     parameters.selectAll = selection.selectAll;
   }
@@ -1209,7 +1208,7 @@ function unlinkCasesFromPlan(container, form, table) {
     window.alert(returnobj.response);
   };
 
-  var url = new String('cases/');
+  var url = 'delete-cases/';
   jQ.ajax({
     'url': url,
     'type': 'POST',
@@ -2295,7 +2294,7 @@ function constructPlanDetailsCasesZone(container, plan_id, parameters) {
         jQ('#id_import_case_zone').toggle();
       });
       jQ('#js' + type + 'add-case-to-plan').bind('click', function() {
-        window.location.href = jQ(this).data('param') + '?a=link_cases';
+        window.location.href = jQ(this).data('param');
       });
       jQ('#js' + type + 'export-case').bind('click', function() {
         exportCase(jQ(this).data('param'), navForm, casesTable);
@@ -2546,9 +2545,7 @@ function resortCasesDragAndDrop(container, button, form, table, parameters, call
       this.disabled = false;
     });
 
-    parameters.a = 'order_cases';
-    parameters.case_sort_by = 'sortkey';
-    var url = 'cases/';
+    var url = 'reorder-cases/';
 
     jQ.ajax({
       'url': url,

--- a/tcms/templates/plan/get.html
+++ b/tcms/templates/plan/get.html
@@ -223,7 +223,7 @@ Nitrate.TestPlans.Instance = {
 		<div class="submit-row">
 			<input type="button" value="x" class="js-close-zone" >
 		</div>
-		<form action="{% url "plan-cases" test_plan.plan_id %}" method="POST" enctype="multipart/form-data">
+		<form action="{% url "plan-import-cases" test_plan.plan_id %}" method="POST" enctype="multipart/form-data">
 			<div  class="right-bar" >
 				<label class="errors" id="import-error">{{ xml_form.xml_file.errors }}</label>
 				{{ xml_form.a }}

--- a/tcms/templates/plan/get_cases.html
+++ b/tcms/templates/plan/get_cases.html
@@ -21,7 +21,7 @@
 						{% if perms.testcases.add_testcase %}
 						<li><input id="js-new-case" class="add_new icon_plan" type="button" value="Write new case" data-params='["{% url "cases-new" %}", {{ test_plan.plan_id }}]'/></li>
 						<li><input id="js-import-case" type="button" class="import icon_plan" value="Import cases from XML" /></li>
-						<li><input id="js-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "plan-cases" test_plan.plan_id %}" /></li>
+						<li><input id="js-add-case-to-plan" type="button" class="search icon_plan" value="Add cases from other plans" data-param="{% url "plan-search-cases-for-link" test_plan.plan_id %}" /></li>
 						{% else %}
 						<li><input type="button" class="add_new icon_plan" disabled="true" value="Write new case"/></li>
 						<li><input type="button" class="import icon_plan" disabled="true" value="Import cases from XML"	/></li>

--- a/tcms/templates/plan/search_case.html
+++ b/tcms/templates/plan/search_case.html
@@ -33,7 +33,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 	<div class="Detailform border-1">
 		<div class="Detailform-variety_0">
 			<div class="grey tit">Search cases to add into this test plan.</div>
-			<form action="{% url "plan-cases" test_plan.plan_id %}" method="post">
+			<form action="{% url "plan-search-cases-for-link" test_plan.plan_id %}" method="post">
 				<fieldset class="no-border">
 				<input type="hidden" name="a" value="link_cases" />
 				<input type="hidden" name="action" value="search" />
@@ -72,9 +72,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 			</form>
 			</fieldset>
 		</div>
-		<form id="id_form_cases" action="{% url "plan-cases" test_plan.plan_id %}" method="post">
-			<input type="hidden" name="a" value="link_cases">
-			<input type="hidden" name="action" value="add_to_plan">
+		<form id="id_form_cases" action="{% url "plan-link-cases" test_plan.plan_id %}" method="post">
 			{% if test_cases %}
 			<div class="middle-list" >
 				<div id="searchcase" class="mixbar">

--- a/tcms/testplans/forms.py
+++ b/tcms/testplans/forms.py
@@ -638,7 +638,6 @@ class XMLRPCEditPlanForm(EditPlanForm):
 
 
 class ImportCasesViaXMLForm(forms.Form):
-    a = forms.CharField(widget=forms.HiddenInput)
     xml_file = CasePlanXMLField(
         label='Upload XML file:',
         help_text='XML file is export with TCMS or Testopia.'

--- a/tcms/testplans/urls/plan_urls.py
+++ b/tcms/testplans/urls/plan_urls.py
@@ -14,7 +14,17 @@ urlpatterns = [
     url(r'^(?P<plan_id>\d+)/edit/$', views.edit, name='plan-edit'),
     url(r'^(?P<plan_id>\d+)/attachment/$', views.attachment, name='plan-attachment'),
     url(r'^(?P<plan_id>\d+)/history/$', views.text_history, name='plan-text-history'),
-    url(r'^(?P<plan_id>\d+)/cases/$', views.cases, name='plan-cases'),
+
+    url(r'^(?P<plan_id>\d+)/reorder-cases/$', views.ReorderCasesView.as_view(),
+        name='plan-reorder-cases'),
+    url(r'^(?P<plan_id>\d+)/link-cases/$', views.LinkCasesView.as_view(),
+        name='plan-link-cases'),
+    url(r'^(?P<plan_id>\d+)/link-cases/search/$', views.LinkCasesSearchView.as_view(),
+        name='plan-search-cases-for-link'),
+    url(r'^(?P<plan_id>\d+)/import-cases/$', views.ImportCasesView.as_view(),
+        name='plan-import-cases'),
+    url(r'^(?P<plan_id>\d+)/delete-cases/$', views.DeleteCasesView.as_view(),
+        name='plan-delete-cases'),
 
     url(r'^(?P<plan_id>\d+)/runs/$', testruns_views.load_runs_of_one_plan,
         name='load_runs_of_one_plan_url'),


### PR DESCRIPTION
CaseActions is moved and separated to individual view classes for each
operation request. Original cases view method is not used anymore and
removed.

Fix #196

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>