### PR TITLE
Refactor plan and case components action views

### DIFF
--- a/tcms/static/js/testcase_actions.js
+++ b/tcms/static/js/testcase_actions.js
@@ -204,7 +204,7 @@ Nitrate.TestCases.Details.on_load = function() {
     fireEvent(jQ('a[href=\"' + window.location.hash + '\"]')[0], 'click');
   }
 
-  jQ('#id_update_component').bind('click', function(e) {
+  jQ('#id_add_component').bind('click', function(e) {
     if (this.diabled) {
       return false;
     }
@@ -222,7 +222,7 @@ Nitrate.TestCases.Details.on_load = function() {
       var params = Nitrate.Utils.formSerialize(this);
       params['case'] = Nitrate.TestCases.Instance.pk;
 
-      var url = Nitrate.http.URLConf.reverse({ name: 'cases_component' });
+      var url = '/cases/add-component/';
       var success = function(t) {
         returnobj = jQ.parseJSON(t.responseText);
 
@@ -251,28 +251,23 @@ Nitrate.TestCases.Details.on_load = function() {
     renderComponentForm(getDialog(), params, form_observe);
   });
 
-  jQ('#id_form_case_component').bind('submit', function(e) {
-    e.stopPropagation();
-    e.preventDefault();
-    var params = Nitrate.Utils.formSerialize(this);
-    var submitButton = jQ(this).find(':submit')[0];
-    params[submitButton.name] = submitButton.value;
-    var parameters = {
-      'a': params['a'],
-      'case': Nitrate.TestCases.Instance.pk,
-      'o_component': params['component']
-    };
-
-    if (!parameters['o_component']) {
-      return false;
-    }
-
+  jQ('#id_remove_component').bind('click', function() {
     var c = window.confirm(default_messages.confirm.remove_case_component);
     if (!c) {
       return false;
     }
 
-    updateCaseComponent(this.action, parameters, json_success_refresh_page);
+    var params = Nitrate.Utils.formSerialize(this.form);
+    if (!params['component']) {
+      return false;
+    }
+
+    var parameters = {
+        'case': Nitrate.TestCases.Instance.pk,
+        'o_component': params['component']
+    };
+
+    updateCaseComponent('/cases/remove-component/', parameters, json_success_refresh_page);
   });
 
   jQ('.link_remove_component').bind('click', function(e) {
@@ -283,11 +278,10 @@ Nitrate.TestCases.Details.on_load = function() {
 
     var form = jQ('#id_form_case_component')[0];
     var parameters = {
-      'a': 'Remove',
       'case': Nitrate.TestCases.Instance.pk,
       'o_component': jQ('input[name="component"]')[jQ('.link_remove_component').index(this)].value
     };
-    updateCaseComponent(form.action, parameters, json_success_refresh_page);
+    updateCaseComponent('/cases/remove-component/', parameters, json_success_refresh_page);
   });
 
   bindSelectAllCheckbox(jQ('#id_checkbox_all_components')[0], jQ('#id_form_case_component')[0], 'component');
@@ -967,20 +961,17 @@ function renderComponentForm(container, parameters, form_observe) {
   jQ(container).show();
 
   var callback = function(t) {
-    var action = Nitrate.http.URLConf.reverse({ name: 'cases_component' });
+    var action = '/cases/add-component/';
     var notice = 'Press "Ctrl" to select multiple default component';
-    var h = jQ('<input>', {'type': 'hidden', 'name': 'a', 'value': 'add'});
     var a = jQ('<input>', {'type': 'submit', 'value': 'Add'});
     var c = jQ('<label>');
-    c.append(h);
     c.append(a);
-    a.bind('click', function(e) { h.val('add'); });
     var f = constructForm(d.html(), action, form_observe, notice, c[0]);
     jQ(container).html(f);
     bind_component_selector_to_product(false, false, jQ('#id_product')[0], jQ('#id_o_component')[0]);
   };
 
-  var url = Nitrate.http.URLConf.reverse({ name: 'cases_component' });
+  var url = '/cases/get-component-form/';
 
   jQ.ajax({
     'url': url,

--- a/tcms/static/js/testplan_actions.js
+++ b/tcms/static/js/testplan_actions.js
@@ -1985,7 +1985,6 @@ function onTestCaseComponentClick(options) {
         'casesSelection': selection
       });
 
-      var url = Nitrate.http.URLConf.reverse({ name: 'cases_component' });
       var cbAfterComponentChanged = function(response) {
         returnobj = jQ.parseJSON(response.responseText);
         if (returnobj.rc != 0) {
@@ -1997,6 +1996,7 @@ function onTestCaseComponentClick(options) {
         clearDialog(c);
       };
 
+      var url = '/cases/add-component/';
       updateCaseComponent(url, params, cbAfterComponentChanged);
     };
     renderComponentForm(c, params, form_observe);

--- a/tcms/templates/case/get_component.html
+++ b/tcms/templates/case/get_component.html
@@ -1,4 +1,4 @@
-<form id="id_form_case_component" action="{% url "cases-component" %}">
+<form id="id_form_case_component">
 	<table class="list" cellspacing="0" cellspan="0" width="100%">
 		<thead>
 			<tr>
@@ -31,13 +31,13 @@
 				<td colspan="4">
 					<div class="addtag">
 						{% if perms.testcases.change_testcasecomponent %}
-						<input id="id_update_component" type="button" value="Add Component" />
+						<input id="id_add_component" type="button" value="Add Component" />
 						{% else %}
-						<input id="id_update_component" type="button" value="Add Component" disabled />
+						<input id="id_add_component" type="button" value="Add Component" disabled />
 						{% endif %}
 
 						{% if perms.testcases.delete_testcasecomponent %}
-						<input id="id_remove_component" type="submit" name="a" value="Remove" />
+						<input id="id_remove_component" type="button" name="a" value="Remove" />
 						{% else %}
 						<input id="id_remove_component" type="button" value="Remove" disabled />
 						{% endif %}

--- a/tcms/templates/plan/get_component.html
+++ b/tcms/templates/plan/get_component.html
@@ -1,4 +1,4 @@
-<form id="id_form_plan_components" action="{% url "plans-component" %}" method="post">
+<form id="id_form_plan_components" action="{% url "plans-component-actions" %}" method="post">
 	<div class="mixbar actions">
 		<div class='marginLeft fixed'>
 			{% if perms.testplans.change_testplancomponent %}

--- a/tcms/testcases/actions.py
+++ b/tcms/testcases/actions.py
@@ -5,11 +5,10 @@ from django.http import JsonResponse
 
 from tcms.core import forms
 from tcms.testcases.forms import CaseCategoryForm
-from tcms.testcases.forms import CaseComponentForm
 from tcms.testcases.models import TestCaseCategory
 
 
-__all__ = ('CategoryActions', 'ComponentActions')
+__all__ = ('CategoryActions',)
 
 
 class BaseActions(object):
@@ -71,101 +70,6 @@ class CategoryActions(BaseActions):
         form = CaseCategoryForm(initial={
             'product': self.product_id,
             'category': self.request.POST.get('o_category'),
-        })
-        form.populate(product_id=self.product_id)
-
-        return HttpResponse(form.as_p())
-
-
-class ComponentActions(BaseActions):
-    """Component actions used by view function `component`"""
-
-    def __get_form(self):
-        self.form = CaseComponentForm(self.request.POST)
-        self.form.populate(product_id=self.product_id)
-        return self.form
-
-    def __check_form_validation(self):
-        form = self.__get_form()
-        if not form.is_valid():
-            return 0, self.render_ajax(forms.errors_to_list(form))
-
-        return 1, form
-
-    def __check_perms(self, perm):
-        perm_name = 'testcases.{}_testcasecomponent'.format(perm)
-        if not self.request.user.has_perm(perm_name):
-            self.ajax_response['rc'] = 1
-            self.ajax_response['response'] = 'Permission denied - ' + perm
-
-            return 0, self.render_ajax(self.ajax_response)
-
-        return 1, True
-
-    def add(self):
-        is_valid, perm = self.__check_perms('add')
-        if not is_valid:
-            return perm
-
-        is_valid, form = self.__check_form_validation()
-        if not is_valid:
-            return form
-
-        tcs = self.get_testcases()
-        for tc in tcs:
-            for c in form.cleaned_data['o_component']:
-                try:
-                    tc.add_component(component=c)
-                except Exception:
-                    self.ajax_response['errors_list'].append({
-                        'case': tc.pk, 'component': c.pk
-                    })
-
-        return self.render_ajax(self.ajax_response)
-
-    def remove(self):
-        is_valid, perm = self.__check_perms('delete')
-        if not is_valid:
-            return perm
-
-        is_valid, form = self.__check_form_validation()
-        if not is_valid:
-            return form
-
-        tcs = self.get_testcases()
-        for tc in tcs:
-            for c in form.cleaned_data['o_component']:
-                try:
-                    tc.remove_component(component=c)
-                except Exception:
-                    self.ajax_response['errors_list'].append({
-                        'case': tc.pk, 'component': c.pk
-                    })
-
-        return self.render_ajax(self.ajax_response)
-
-    def update(self):
-        is_valid, perm = self.__check_perms('change')
-        if not is_valid:
-            return perm
-
-        is_valid, form = self.__check_form_validation()
-        if not is_valid:
-            return form
-
-        # self.tcs.update(category = self.form.cleaned_data['category'])
-        tcs = self.get_testcases()
-        for tc in tcs:
-            tc.clear_components()
-            for c in form.cleaned_data['o_component']:
-                tc.add_component(component=c)
-
-        return self.render_ajax(self.ajax_response)
-
-    def render_form(self):
-        form = CaseComponentForm(initial={
-            'product': self.product_id,
-            'component': self.request.POST.getlist('o_component'),
         })
         form.populate(product_id=self.product_id)
 

--- a/tcms/testcases/urls/cases_urls.py
+++ b/tcms/testcases/urls/cases_urls.py
@@ -12,9 +12,15 @@ urlpatterns = [
     url(r'^ajax/$', views.ajax_search, name='cases-ajax-search'),
     url(r'^automated/$', views.automated, name='cases-automated'),
     url(r'^tag/$', views.tag, name='cases-tag'),
-    url(r'^component/$', views.component, name='cases-component'),
     url(r'^category/$', views.category, name='cases-category'),
     url(r'^clone/$', views.clone, name='cases-clone'),
     url(r'^printable/$', views.printable, name='cases-printable'),
     url(r'^export/$', views.export, name='cases-export'),
+
+    url(r'^add-component/$', views.AddComponentView.as_view(),
+        name='cases-add-component'),
+    url(r'^remove-component/$', views.RemoveComponentView.as_view(),
+        name='cases-remove-component'),
+    url(r'^get-component-form/$', views.GetComponentFormView.as_view(),
+        name='cases-get-component-form'),
 ]

--- a/tcms/testplans/urls/plans_urls.py
+++ b/tcms/testplans/urls/plans_urls.py
@@ -12,5 +12,8 @@ urlpatterns = [
     url(r'^clone/$', views.clone, name='plans-clone'),
     url(r'^printable/$', views.printable, name='plans-printable'),
     url(r'^export/$', views.export, name='plans-export'),
-    url(r'^component/$', views.component, name='plans-component'),
+    # url(r'^component/$', views.component, name='plans-component'),
+
+    url(r'^component/$', views.PlanComponentsActionView.as_view(),
+        name='plans-component-actions'),
 ]


### PR DESCRIPTION
Both plan and case components have similar actions, add, remove, update
and get components UI. But, they have different behavior to accomplish
each action. So, original actions implementation is just refactored
using class-based generic view. It is impossible to merge them or share
lots of code.

Fix #193

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>