### PR TITLE
Fix testenv playbook

### DIFF
--- a/contrib/ansible/testenv/testenv.yml
+++ b/contrib/ansible/testenv/testenv.yml
@@ -32,7 +32,8 @@
     - name: Service docker
       systemd: name=docker state=started enabled=yes
 
-    - stat: path=/var/lib/pgsql/data
+    - name: Check if PostgreSQL data cluster is initialized
+      stat: path=/var/lib/pgsql/data/pg_hba.conf
       register: pgsql_data
 
     - name: Init PostgreSQL data cluster


### PR DESCRIPTION
This fixes the step of checking if PostgreSQL data cluster is already
initialized. Directory /var/lib/pgsql/data exists after
postgresql-server is installed. So, the original way of checking this
directory is not stable.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>