### PR TITLE
Use custom BooleanField for TestBuild.is_active

### DIFF
--- a/tcms/core/models/fields.py
+++ b/tcms/core/models/fields.py
@@ -3,7 +3,9 @@ import datetime
 import six
 
 from pymysql.constants import FIELD_TYPE
+from django.core.exceptions import ValidationError
 from django.db.models.fields import IntegerField
+from django.db.models.fields import BooleanField
 from django.db.backends.mysql.base import django_conversions
 
 from tcms.core.forms.fields import DurationField as DurationFormField
@@ -50,3 +52,15 @@ class DurationField(IntegerField):
         defaults = {'help_text': 'Enter duration in the format: DDHHMM'}
         defaults.update(kwargs)
         return form_class(**defaults)
+
+
+class NitrateBooleanField(BooleanField):
+    """Custom boolean field to allow accepting arbitrary bool values"""
+
+    def to_python(self, value):
+        if value in (1, '1', 'true', 'True', True):
+            return True
+        if value in (0, '0', 'false', 'False', False):
+            return False
+        raise ValidationError(
+            '{} is not recognized as a bool value.'.format(value))

--- a/tcms/management/models.py
+++ b/tcms/management/models.py
@@ -5,6 +5,7 @@ from django.db import models
 
 from tcms.core.models import TCMSActionModel
 from tcms.core.utils import calc_percent
+from tcms.core.models.fields import NitrateBooleanField
 
 # FIXME: plugins_support is no longer available. dead code here.
 try:
@@ -223,7 +224,7 @@ class TestBuild(TCMSActionModel):
     product = models.ForeignKey(Product, related_name='build')
     milestone = models.CharField(max_length=20, default='---')
     description = models.TextField(blank=True)
-    is_active = models.BooleanField(db_column='isactive', default=True)
+    is_active = NitrateBooleanField(db_column='isactive', default=True)
     objects = TestBuildManager()
 
     class Meta:


### PR DESCRIPTION
A customized BooleanField is defined and used for TestBuild.is_active
to allow accepting even true or false from frontend. Django's builtin
BooleanField does not accept 'true' and 'false'.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>