### PR TITLE
Update MOTD_LOGIN setting

### DIFF
--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -298,19 +298,11 @@ PLAN_RUNS_PAGE_SIZE = 20
 
 # Site-specific messages
 
-# The site can supply optional "message of the day" style
-# banners, similar to /etc/motd
-# They are fragments of HTML.
+# The site can supply optional "message of the day" style banners, similar to
+# /etc/motd. They are fragments of HTML.
 
-# This one, if set, is shown on the front page.
-# It is only shown to authenticated users
-#MOTD_AUTH = """<p>This is a development instance of the TCMS</p>
-# <p>(this is MOTD_AUTH)</p>"""
-
-# This one, if set, is shown on the login screen.
-# It is shown to unauthenticated users
-#MOTD_LOGIN = """<p>This is a development instance of the TCMS</p>
-# <p>(this is MOTD_LOGIN)</p>"""
+# This if set, is shown on the login/registration screens.
+# MOTD_LOGIN = ''
 
 # The URLS will be list in footer
 # Example:

--- a/tcms/settings/product.py
+++ b/tcms/settings/product.py
@@ -58,19 +58,9 @@ EMAIL_FROM = 'noreply@example.com'
 
 # Site-specific messages
 
-# This one, if set, is shown on the front page.
-# It is only shown to authenticated users
-MOTD_AUTH = """
-<p>This is the development server for the production instance of the TCMS,
-connected to a copy of the testopia database.</p>
-"""
-
 # First run - to detemine need port user or not.
 FIRST_RUN = False
 
-MOTD_LOGIN = """<p>This is the development server of the TCMS (for testing).</p>
-<p>Please use your kerberos user name and password.</p>
-"""
 # You can add a help link on the footer of home page as following format:
 # ('http://foo.com', 'foo')
 FOOTER_LINKS = (


### PR DESCRIPTION
- remove mention of kerberos b/c users who don't have it get confused
- remove MOTH_AUTH because it is not used at all

Updated:

While reviewing this patch, I'm not quite sure how it is useful for
daily use for users. And showing text in either h2 or h3 seems make no
sense. On the other hand, as what the comment of MOTD_LOGIN says, it
could be good to make it configurable in database so that the messages
can updated easily and no need to restart server to apply the
changes.

So, at this moment, I just update this patch to keep MOTD_LOGIN empty
and leave the decision of what message should be displayed to users who
might find it is useful for his/her use cases.

Signed-off-by: Mr. Senko <atodorov@mrsenko.com>
Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>