### PR TITLE
Fix wrong method calls in report data module

### DIFF
--- a/tcms/core/db.py
+++ b/tcms/core/db.py
@@ -78,7 +78,7 @@ class SQLExecution(object):
 
     @property
     def scalar(self):
-        row = self.rows.next()
+        row = six.next(self.rows)
         for key, value in six.iteritems(row):
             return value
 

--- a/tcms/report/data.py
+++ b/tcms/report/data.py
@@ -562,7 +562,7 @@ class TestingReportByCaseRunTesterData(TestingReportBaseData):
         tested_by_usernames = self.get_usernames(status_matrix.keys())
 
         def walk_status_matrix_rows():
-            tested_by_ids = sorted(six.iteritems(status_matrix),
+            tested_by_ids = sorted(status_matrix.iteritems(),
                                    key=lambda item: item[0])
             for tested_by_id, status_subtotal in tested_by_ids:
                 tested_by_username = tested_by_usernames.get(tested_by_id,
@@ -714,11 +714,11 @@ class TestingReportByCasePriorityData(TestingReportBaseData):
 
         def walk_status_matrix_rows():
             prev_build_id = None
-            ordered_builds = sorted(six.iteritems(status_matrix),
+            ordered_builds = sorted(status_matrix.iteritems(),
                                     key=lambda item: item[0])
             for build_id, priorities in ordered_builds:
                 build_rowspan = len(priorities)
-                ordered_priorities = sorted(six.iteritems(priorities),
+                ordered_priorities = sorted(priorities.iteritems(),
                                             key=lambda item: item[0].value)
                 build_name = builds_names.get(build_id, '')
                 for priority, status_subtotal in ordered_priorities:
@@ -772,7 +772,7 @@ class TestingReportByPlanTagsData(TestingReportBaseData):
         tags_names = self.get_tags_names(status_matrix.keys())
 
         def walk_status_matrix_rows():
-            ordered_tags = sorted(six.iteritems(status_matrix),
+            ordered_tags = sorted(status_matrix.iteritems(),
                                   key=lambda item: item[0])
             for tag_id, status_subtotal in ordered_tags:
                 yield tags_names.get(tag_id, ''), \
@@ -843,7 +843,7 @@ class TestingReportByPlanTagsDetailData(TestingReportByPlanTagsData):
 
         def walk_status_matrix():
             status_matrix.leaf_values_count(value_in_row=True)
-            ordered_builds = sorted(six.iteritems(status_matrix),
+            ordered_builds = sorted(status_matrix.iteritems(),
                                     key=lambda item: item[0])
             for tag_id, builds in ordered_builds:
                 # Data on top of each status matrix under each tag
@@ -872,12 +872,12 @@ class TestingReportByPlanTagsDetailData(TestingReportByPlanTagsData):
         prev_build = None
         prev_plan = None
 
-        ordered_builds = sorted(six.iteritems(root_matrix), key=sort_key)
+        ordered_builds = sorted(root_matrix.iteritems(), key=sort_key)
         for build, plans in ordered_builds:
-            ordered_plans = sorted(six.iteritems(plans), key=sort_key)
+            ordered_plans = sorted(plans.iteritems(), key=sort_key)
             build_rowspan = plans.leaf_values_count(value_in_row=True)
             for plan, runs in ordered_plans:
-                ordered_runs = sorted(six.iteritems(runs), key=sort_key)
+                ordered_runs = sorted(runs.iteritems(), key=sort_key)
                 plan_rowspan = runs.leaf_values_count(value_in_row=True)
                 for run, status_subtotal in ordered_runs:
                     if build == prev_build:
@@ -932,7 +932,7 @@ class TestingReportByPlanBuildData(TestingReportBaseData):
         status_matrix = self.status_matrix(form)
 
         def walk_status_matrix_rows():
-            ordered_plans = sorted(six.iteritems(status_matrix),
+            ordered_plans = sorted(status_matrix.iteritems(),
                                    key=lambda item: item[0].pk)
             for plan, status_subtotal in ordered_plans:
                 yield plan, \
@@ -947,7 +947,7 @@ class TestingReportByPlanBuildData(TestingReportBaseData):
 
             # only for displaying plan names
             'plans': (plan.name for plan, value in
-                      sorted(six.iteritems(status_matrix),
+                      sorted(status_matrix.iteritems(),
                              key=lambda item: item[0].pk))
         }
 
@@ -997,7 +997,7 @@ class TestingReportByPlanBuildDetailData(TestingReportByPlanBuildData):
         status_matrix.leaf_values_count(value_in_row=True)
 
         def walk_status_matrix_rows():
-            ordered_plans = sorted(six.iteritems(status_matrix),
+            ordered_plans = sorted(status_matrix.iteritems(),
                                    key=lambda item: item[0].pk)
             for plan, builds in ordered_plans:
                 builds_count = builds_subtotal.get(plan, 0)
@@ -1017,12 +1017,12 @@ class TestingReportByPlanBuildDetailData(TestingReportByPlanBuildData):
     def walk_status_matrix_section(self, status_matrix_section):
         prev_build = None
 
-        ordered_builds = sorted(six.iteritems(status_matrix_section),
+        ordered_builds = sorted(status_matrix_section.iteritems(),
                                 key=lambda item: item[0].pk)
         for build, runs in ordered_builds:
             build_rowspan = runs.leaf_values_count(value_in_row=True)
 
-            ordered_runs = sorted(six.iteritems(runs),
+            ordered_runs = sorted(runs.iteritems(),
                                   key=lambda item: item[0].pk)
 
             for run, status_subtotal in ordered_runs:


### PR DESCRIPTION
This patch fixes wrong calls to iterator next function and iteritems on
a dict-like object.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>