### PR TITLE
Rewrite UrlMixin

### DIFF
--- a/tcms/templates/case/get_details_case_run.html
+++ b/tcms/templates/case/get_details_case_run.html
@@ -92,7 +92,7 @@
 						<li>
 							<table cellpadding="3" cellspacing="0" border="0">
 								<tr>
-									<td><a href="{{ bugs.0.get_url }}">{{ bug_id }}</a></td>
+									<td><a href="{{ bugs.0.get_full_url }}">{{ bug_id }}</a></td>
 								<td>
 								{% for bug in bugs %}
 								    {% if bug.case_run_id %}

--- a/tcms/templates/mail/edit_case.txt
+++ b/tcms/templates/mail/edit_case.txt
@@ -1,10 +1,10 @@
 TestCase [{{ test_case.summary }}] has been updated by {{ test_case.current_user.username|default:"someone" }}
 
 Case -
-{{ test_case.get_url }}?#log
+{{ test_case.get_full_url }}?#log
 
 --
-Configure mail: {{test_case.get_url}}/edit/
+Configure mail: {{ test_case.get_full_url }}/edit/
 ------- You are receiving this mail because: -------
 You have subscribed to the changes of this TestCase
 You are related to this TestCase

--- a/tcms/templates/plan/get.html
+++ b/tcms/templates/plan/get.html
@@ -35,7 +35,7 @@ Nitrate.TestPlans.Instance = {
 		num_cases: {{ test_plan.case.count }},
 		num_runs: {{ test_plan.run.count }},
 		num_children: {{ test_plan.child_set.count }},
-		get_url_path: '{{ test_plan.get_url_path }}'
+		get_url_path: '{{ test_plan.get_absolute_url }}'
 	}
 }
 </script>

--- a/tcms/templates/report/custom_details_case_runs.html
+++ b/tcms/templates/report/custom_details_case_runs.html
@@ -11,14 +11,14 @@
 	</tr>
 	{% for test_case_run, bugs, comments in case_runs %}
 	<tr>
-		<td valign="top"><a href="{{ test_case_run.case.get_url_path }}">{{ test_case_run.case.pk }}</a></td>
+		<td valign="top"><a href="{{ test_case_run.case.get_absolute_url }}">{{ test_case_run.case.pk }}</a></td>
 		<td valign="top"><a href="{% url "run-get" test_case_run.run_id %}#caserun_{{ test_case_run.pk }}">{{ test_case_run.pk }}</a></td>
 		<td valign="top">{{ test_case_run.case.summary }}</td>
 		<td valign="top">{{ test_case_run.case.category }}</td>
 		<td valign="top">{{ test_case_run.tested_by }}</td>
 		<td valign="top">
 		{% for bug in bugs %}
-			<a href="{{ bug.get_absolute_url }}">{{ bug }}</a>,
+			<a href="{{ bug.get_full_url }}">{{ bug }}</a>,
 		{% empty %}
 			<span class="grey"></span>
 		{% endfor %}
@@ -45,7 +45,7 @@
 	{% for bug in test_case_run.bug.all %}
 	<h1>bottom bugs</h1>
 	<tr class="border-bottom">
-		<td valign="top" colspan="7"><a href="{{ bug.get_url }}">{{ get_url }}</a> </td>
+		<td valign="top" colspan="7"><a href="{{ bug.get_full_url }}">{{ bug }}</a> </td>
 	</tr>
 	{% endfor %}
 

--- a/tcms/templates/report/custom_details_status_matrix.html
+++ b/tcms/templates/report/custom_details_status_matrix.html
@@ -20,10 +20,10 @@
 		<tr>
 			{% ifnotequal plan None %}
 			<td class="group_by" valign="middle" rowspan="{{ plan.1 }}" data-plan-id="{{ plan.0.plan_id }}">
-			  <a href="{{ plan.0.get_url_path }}">[{{ plan.0.plan_id }}] {{ plan.0.name }}</a>
+			  <a href="{{ plan.0.get_absolute_url }}">[{{ plan.0.plan_id }}] {{ plan.0.name }}</a>
 			</td>
 			{% endifnotequal %}
-			<td valign="top"><a href="{{ run.get_url_path }}">[{{ run.run_id }}] {{ run.summary }}</a></td>
+			<td valign="top"><a href="{{ run.get_absolute_url }}">[{{ run.run_id }}] {{ run.summary }}</a></td>
 			<td valign="top">{{ status_count.IDLE|default:'' }}</td>
 			<td valign="top">{{ status_count.RUNNING|default:'' }}</td>
 			<td valign="top">{{ status_count.PAUSED|default:'' }}</td>

--- a/tcms/templates/report/testing-report/per_plan_build.html
+++ b/tcms/templates/report/testing-report/per_plan_build.html
@@ -55,7 +55,7 @@
 				{% ifnotequal build.1 None %}
 				<td rowspan="{{ build.1 }}" class="bgRowspan"><span>{{ build.0 }}</span></td>
 				{% endifnotequal %}
-				<td><a href="{{ run.get_url_path }}">{{ run.summary }}</a></td>
+				<td><a href="{{ run.get_absolute_url }}">{{ run.summary }}</a></td>
 				<td><a href="{{ report_url }}{{path_without_build}}&r_build={{build.0.pk}}&run={{ run.pk }}&status=idle">{{ status_subtotal.IDLE|default:0 }}</a></td>
 				<td><a href="{{ report_url }}{{path_without_build}}&r_build={{build.0.pk}}&run={{ run.pk }}&status=running">{{ status_subtotal.RUNNING|default:0 }}</a></td>
 				<td><a href="{{ report_url }}{{path_without_build}}&r_build={{build.0.pk}}&run={{ run.pk }}&status=paused">{{ status_subtotal.PAUSED|default:0 }}</a></td>

--- a/tcms/templates/report/testing-report/per_plan_tag.html
+++ b/tcms/templates/report/testing-report/per_plan_tag.html
@@ -57,7 +57,7 @@
 				<a href="{{ plan.0.get_absolute_url }}">[{{ plan.0.pk }}] {{ plan.0.name }}</a>
 			</td>
 			{% endifnotequal %}
-			<td><a href="{{ run.get_url_path }}">{{ run.summary }}</a></td>
+			<td><a href="{{ run.get_absolute_url }}">{{ run.summary }}</a></td>
 			<td><a href="{{ report_url }}{{path_without_build}}&r_build={{ build.0.pk }}&plan_tag={{ tag_name }}&run={{ run.pk }}&status=idle">{{ status_subtotal.IDLE|default:0 }}</a></td>
 			<td><a href="{{ report_url }}{{path_without_build}}&r_build={{ build.0.pk }}&plan_tag={{ tag_name }}&run={{ run.pk }}&status=running">{{ status_subtotal.RUNNING|default:0 }}</a></td>
 			<td><a href="{{ report_url }}{{path_without_build}}&r_build={{ build.0.pk }}&plan_tag={{ tag_name }}&run={{ run.pk }}&status=paused">{{ status_subtotal.PAUSED|default:0 }}</a></td>

--- a/tcms/testcases/models.py
+++ b/tcms/testcases/models.py
@@ -533,7 +533,7 @@ class TestCase(TCMSActionModel):
     def remove_tag(self, tag):
         self.tag.through.objects.filter(case=self.pk, tag=tag.pk).delete()
 
-    def get_url_path(self, request=None):
+    def get_absolute_url(self, request=None):
         return reverse('case-get', args=[self.pk, ])
 
     def _get_email_conf(self):
@@ -666,9 +666,9 @@ class TestCaseBug(TCMSActionModel):
 
     def get_absolute_url(self):
         # Upward compatibility code
-        return self.get_url()
+        return self.get_full_url()
 
-    def get_url(self):
+    def get_full_url(self):
         return self.bug_system.url_reg_exp % self.bug_id
 
 

--- a/tcms/testcases/tests/test_models.py
+++ b/tcms/testcases/tests/test_models.py
@@ -267,7 +267,7 @@ Configure mail: {2}/edit/
 You have subscribed to the changes of this TestCase
 You are related to this TestCase'''.format(self.case.summary,
                                            'editor',
-                                           self.case.get_url())
+                                           self.case.get_full_url())
 
         self.assertEqual(1, len(mail.outbox))
         self.assertEqual(expected_mail_body, mail.outbox[0].body)

--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.models import Max
 from django.db.models.signals import post_save, post_delete, pre_save
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 
 from uuslug import slugify
 
@@ -228,15 +229,11 @@ class TestPlan(TCMSActionModel):
     def delete_case(self, case):
         TestCasePlan.objects.filter(case=case.pk, plan=self.pk).delete()
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('plan-get', (), {
+        return reverse('plan-get', kwargs={
             'plan_id': self.plan_id,
             'slug': slugify(self.name),
         })
-
-    def get_url_path(self, request=None):
-        return self.get_absolute_url()
 
     def get_case_sortkey(self):
         '''

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -254,7 +254,7 @@ def all(request, template_name='plan/all.html'):
         return HttpResponse(serializers.serialize(
             request.GET.get('f', 'json'),
             tps,
-            extras=('num_cases', 'num_runs', 'num_children', 'get_url_path')
+            extras=('num_cases', 'num_runs', 'num_children', 'get_absolute_url')
         ))
 
     if request.GET.get('t') == 'html':

--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -147,14 +147,8 @@ class TestRun(TCMSActionModel):
 
         return True
 
-    def get_absolute_url(self, request=None):
-        # Upward compatibility code
-        if request:
-            return request.build_absolute_uri(
-                reverse('run-get', args=[self.pk, ])
-            )
-
-        return self.get_url(request)
+    def get_absolute_url(self):
+        return reverse('run-get', args=[self.pk])
 
     def get_notify_addrs(self):
         """
@@ -169,9 +163,6 @@ class TestRun(TCMSActionModel):
             if tcr.assignee_id:
                 to.append(tcr.assignee.email)
         return list(set(to))
-
-    def get_url_path(self):
-        return reverse('run-get', args=[self.pk])
 
     # FIXME: rewrite to use multiple values INSERT statement
     def add_case_run(self, case, case_run_status=1, assignee=None,


### PR DESCRIPTION
UrlMixin is too old. It can be rewrite in Django builtin functionalities
nowadays. In templates, a get_absolute_url is enough to render the path
part of a model object, and some of URLs can be constructed by using
Site app in the meanwhile.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>