### PR TITLE
Name Nitrate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
 
 
 setup(
-    name='nitrate',
+    name='Nitrate',
     version=pkg_version,
     description='Test Case Management System',
     long_description=get_long_description(),


### PR DESCRIPTION
Yes, it should be Nitrate for the package name instead of "nitrate".

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>