### PR TITLE
Drop django-preserialize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ coverage==4.5.1
 Django==1.11.11
 django-contrib-comments==1.8.0
 django-debug-toolbar==1.7
-django-preserialize==1.2.1
 django-tinymce==2.6.0
 django-uuslug==1.1.8
 docutils==0.14

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ install_requires = [
     'beautifulsoup4 >= 4.1.1',
     'celery == 4.1.0',
     'django-contrib-comments == 1.8.0',
-    'django-preserialize == 1.2.1',
     'django-tinymce == 2.6.0',
     'django-uuslug == 1.1.8',
     'django >= 1.10,<2.0',

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -22,7 +22,6 @@ from django.template.loader import get_template
 from django.views.decorators.http import require_GET
 from django.views.decorators.http import require_http_methods
 from django.views.generic import View
-from preserialize.serialize import serialize
 from uuslug import slugify
 
 from tcms.core.db import SQLExecution
@@ -254,12 +253,20 @@ def all(request, template_name='plan/all.html'):
         tps = tps.order_by('name')
 
     if request.GET.get('t') == 'ajax':
-        return JsonResponse(
-            serialize(tps, fields=[
-                'pk', 'name', 'is_active', 'parent_id',
-                'num_cases', 'num_runs', 'num_children', 'get_url_path'
-            ]),
-            safe=False)
+        data = [
+            dict(
+                pk=plan.pk,
+                name=plan.name,
+                is_active=plan.is_active,
+                parent_id=plan.parent_id,
+                num_cases=plan.num_cases,
+                num_runs=plan.num_runs,
+                num_children=plan.num_children,
+                get_url_path=plan.get_absolute_url(),
+            )
+            for plan in tps
+        ]
+        return JsonResponse(data, safe=False)
 
     if request.GET.get('t') == 'html':
         if request.GET.get('f') == 'preview':


### PR DESCRIPTION
So far, django-preserialize does not support Django>=1.11 and project
maintainer does not have time to implement that. Instead of waiting for
someone else to do that, this patch drops django-preserialize as a
for now.

Fixes #311

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>