### PR TITLE
Get issuetracker credential

### DIFF
--- a/tcms/integration/issuetracker/services.py
+++ b/tcms/integration/issuetracker/services.py
@@ -117,8 +117,8 @@ class IssueTrackerService(object):
         :param str description: optional description of this issue.
         :param bool add_case_to_issue: whether to link case to issue tracker's
             external tracker. Defaults to not link test case to the new issue,
-            however if it is required, :meth:`add_external_tracker
-            <tcms.integration.issuetracker.services.IssueTrackerService.add_external_tracker>`
+            however if it is required, :meth:`link_external_tracker
+            <tcms.integration.issuetracker.services.IssueTrackerService.link_external_tracker>`
             has to be called explicitly.
         :return: the newly created issue.
         :rtype: :class:`Issue <tcms.integration.issuetracker.models.Issue>`
@@ -133,7 +133,7 @@ class IssueTrackerService(object):
         issue.full_clean()
         issue.save()
         if self.tracker_model.allow_add_case_to_issue and add_case_to_issue:
-            self.add_external_tracker(issue)
+            self.link_external_tracker(issue)
         return issue
 
     def format_issue_report_content(self, build_name, case_text):
@@ -373,7 +373,7 @@ class RHBugzilla(IssueTrackerService):
 
     def link_external_tracker(self, issue):
         """Link case to issue's external tracker in remote Bugzilla service"""
-        bugzilla_external_track.delay(self.tracker_model.api_url, issue)
+        bugzilla_external_track.delay(self.tracker_model, issue)
 
 
 class JIRA(IssueTrackerService):

--- a/tcms/integration/issuetracker/task.py
+++ b/tcms/integration/issuetracker/task.py
@@ -3,18 +3,18 @@
 import warnings
 
 from celery import shared_task
-from django.conf import settings
 from six.moves import xmlrpc_client
 
 
 @shared_task
-def bugzilla_external_track(api_url, issue):
+def bugzilla_external_track(issue_tracker, issue):
     """Link issue to bug external tracker"""
     try:
-        proxy = xmlrpc_client.ServerProxy(api_url)
+        cred = issue_tracker.credential
+        proxy = xmlrpc_client.ServerProxy(issue_tracker.api_url)
         proxy.ExternalBugs.add_external_bug({
-            'Bugzilla_login': settings.BUGZILLA_USER,
-            'Bugzilla_password': settings.BUGZILLA_PASSWORD,
+            'Bugzilla_login': cred['username'],
+            'Bugzilla_password': cred['password'],
             'bug_ids': [int(issue.issue_key)],
             'external_bugs': [{
                 'ext_bz_bug_id': str(issue.case.pk),

--- a/tcms/integration/issuetracker/tests/test_models.py
+++ b/tcms/integration/issuetracker/tests/test_models.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import tcms.integration.issuetracker.factories as f
+import io
+import os
+import re
+import tempfile
 
 from django import test
+from tcms.integration.issuetracker.models import CredentialTypes
 from tcms.tests import HelperAssertions
+import tcms.integration.issuetracker.factories as f
 
 
 class TestIssueTrackerValidation(HelperAssertions, test.TestCase):
@@ -23,3 +28,81 @@ class TestIssueTrackerValidation(HelperAssertions, test.TestCase):
         st.issue_report_params = 'product: name\ncustom_field: a:b:c'
         self.assertValidationError(
             'issue_report_params', r"Line .+ contains multiple ':'", st.full_clean)
+
+
+class TestGetIssueTrackerCredential(test.TestCase):
+    """Test IssueTracker property credential"""
+
+    def setUp(self):
+        fd, self.user_pwd_secret_file = tempfile.mkstemp()
+        with io.open(fd, 'w', encoding='utf-8') as f:
+            f.write(u'[issuetracker]\nusername = admin\npassword = admin\n')
+
+        fd, self.token_secret_file = tempfile.mkstemp()
+        with io.open(fd, 'w', encoding='utf-8') as f:
+            f.write(u'[issuetracker]\ntoken = abcde\n')
+
+    def tearDown(self):
+        os.unlink(self.user_pwd_secret_file)
+        os.unlink(self.token_secret_file)
+
+    def test_get_noneed_credential(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.NoNeed.name)
+        self.assertEqual({}, issue_tracker.credential)
+
+    def test_get_user_pwd_credential_from_secret_file(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.UserPwd.name)
+        f.UserPwdCredentialFactory(
+            secret_file=self.user_pwd_secret_file,
+            issue_tracker=issue_tracker)
+        self.assertEqual({'username': 'admin', 'password': 'admin'},
+                         issue_tracker.credential)
+
+    def test_get_user_pwd_credential_from_database(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.UserPwd.name)
+        f.UserPwdCredentialFactory(
+            username='abc',
+            password='abc',
+            issue_tracker=issue_tracker)
+        self.assertEqual({'username': 'abc', 'password': 'abc'},
+                         issue_tracker.credential)
+
+    def test_get_token_credential_from_secret_file(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.Token.name)
+        f.TokenCredentialFactory(
+            secret_file=self.token_secret_file,
+            issue_tracker=issue_tracker)
+        self.assertEqual({'token': 'abcde'}, issue_tracker.credential)
+
+    def test_get_token_credential_from_database(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.Token.name)
+        f.TokenCredentialFactory(
+            token='234wer',
+            issue_tracker=issue_tracker)
+        self.assertEqual({'token': '234wer'}, issue_tracker.credential)
+
+    def assert_property_credential(self, issue_tracker):
+        try:
+            issue_tracker.credential
+        except ValueError as e:
+            if not re.search(r'credential is not set', str(e)):
+                self.fail('Expected ValueError is not raised. Instead, another'
+                          ' ValueError is raised with message: {}'
+                          .format(str(e)))
+        else:
+            self.fail('Expected ValueError is not raised.')
+
+    def test_user_pwd_credential_not_set(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.UserPwd.name)
+        self.assert_property_credential(issue_tracker)
+
+    def test_token_credential_not_set(self):
+        issue_tracker = f.IssueTrackerFactory(
+            credential_type=CredentialTypes.Token.name)
+        self.assert_property_credential(issue_tracker)

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -324,13 +324,9 @@ SET_ADMIN_AS_SUPERUSER = False
 # Bugzilla author xmlrpc url
 # Required by bugzilla authentication backend
 BUGZILLA3_RPC_SERVER = ''
-BUGZILLA_URL = ''
 
 # JIRA URL
 JIRA_URL = ''
-
-# Turn on/off bugzilla external tracker
-BUGZILLA_EXTERNAL_TRACKER = False
 
 # Turn on/off listening signals sent by models.
 LISTENING_MODEL_SIGNAL = True

--- a/tcms/settings/product.py
+++ b/tcms/settings/product.py
@@ -44,9 +44,6 @@ DATABASE_ROUTERS = ['tcms.core.utils.tcms_router.RWRouter']
 # Bugzilla integration setttings
 # Config following settings if your want to integrate with bugzilla
 BUGZILLA3_RPC_SERVER = ''
-BUGZILLA_URL = ''
-BUGZILLA_USER = ''
-BUGZILLA_PASSWORD = ''
 
 # JIRA integration setttings
 # Config following settings if your want to integrate with JIRA


### PR DESCRIPTION
Each issue tracker could have an associated credential, and is
accessible via property ``credential``. Task bugzilla_external_tracker
is fixed with this new credential to pass bugzilla username and
password. Hence, original configs in settings module is not used any
more, which are removed from both common and product settings modules.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>