### PR TITLE
Remove reference to nonexisting jquery.min.js

### DIFF
--- a/tcms/templates/tcms_base.html
+++ b/tcms/templates/tcms_base.html
@@ -10,7 +10,6 @@
 	<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}style/base.css" media="screen" />
 	<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}style/print.css" media="print" />
 	{% block custom_stylesheet %}{% endblock %}
-	<script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.min.js"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.init.js"></script>
 	<script type="text/javascript" src='{{ STATIC_URL }}js/lib/jquery-1.7.2.min.js'></script>
 	<script type="text/javascript" src='{{ STATIC_URL }}js/lib/jquery-ui-1.8.20.min.js'></script>


### PR DESCRIPTION
SCRIPT tag referencing nonexisting jquery.min.js is removed from base
template.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>