### PR TITLE
Remove celery from install_requires and kobo from testenv deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ def get_long_description():
 
 install_requires = [
     'beautifulsoup4 >= 4.1.1',
-    'celery == 4.2.0',
     'django >= 1.11,<3.0',
     'django-contrib-comments == 1.8.0',
     'django-tinymce == 2.7.0',

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     py36: celery == 4.2.0
     django200: Django>=2.0,<2.1
     django210: Django>=2.1,<3.0
-    kobo == 0.9.0
 usedevelop = True
 extras =
     krbauth


### PR DESCRIPTION
celery was moved to extra async, and kobo is one of the dependencies
listed in setup.py so it is not necessary to list it again in testenv
deps in tox.ini.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>