### PR TITLE
Extend Travis-CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,29 @@ services:
 - docker
 matrix:
   include:
+  # Matrix of Python 2.7, 3.6, 3.7 and Django 1.11.x
   - python: "2.7"
     env: DJANGO_REL="django>=1.11,<2.0"
   - python: "3.6"
-    env: DJANGO_REL="django>=1.11,<2.0" NITRATE_DB=mysql
-  - python: "3.6"
-    env: DJANGO_REL="django>=1.11,<2.0" NITRATE_DB=mariadb
-  - python: "3.6"
-    env: DJANGO_REL="django>=1.11,<2.0" NITRATE_DB=postgres
+    env: DJANGO_REL="django>=1.11,<2.0"
   - python: "3.7"
     env: DJANGO_REL="django>=1.11,<2.0"
+  # Matrix of Python 3.6, 3.7 and Django 2.0.x
+  - python: "3.6"
+    env: DJANGO_REL="django>=2.0,<2.1"
+  - python: "3.7"
+    env: DJANGO_REL="django>=2.0,<2.1"
+  # Matrix of Python 3.6, 3.7 and Django 2.1.x
+  - python: "3.6"
+    env: DJANGO_REL="django>=2.1,<3.0"
+  - python: "3.6"
+    env: DJANGO_REL="django>=2.1,<3.0" NITRATE_DB=mysql
+  - python: "3.6"
+    env: DJANGO_REL="django>=2.1,<3.0" NITRATE_DB=mariadb
+  - python: "3.6"
+    env: DJANGO_REL="django>=2.1,<3.0" NITRATE_DB=postgres
+  - python: "3.7"
+    env: DJANGO_REL="django>=2.1,<3.0"
 before_install:
 - docker pull mysql:5.7
 - docker pull mariadb:10.2.21


### PR DESCRIPTION
Now, Nitrate has been patched to work with Django 2.x. It is time to
extend the test matrix in Travis-CI to test more.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>