### PR TITLE
Remove deprecated parameter context from Field.from_db_value

### DIFF
--- a/src/tcms/core/models/fields.py
+++ b/src/tcms/core/models/fields.py
@@ -36,7 +36,7 @@ class DurationField(IntegerField):
         else:
             raise TypeError('Unable to convert %s to timedelta.' % value)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         if value is None:
             return value
         return datetime.timedelta(seconds=value)


### PR DESCRIPTION
Fixes #388

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>