### PR TITLE
Use mysqlclient from now on

### DIFF
--- a/contrib/travis-ci/Dockerfile
+++ b/contrib/travis-ci/Dockerfile
@@ -6,7 +6,7 @@ with a database image." \
       version="0.1"
 
 # Use mysql provided by mariadb to connect MySQL server or MariaDB server.
-RUN dnf install -y gcc redhat-rpm-config make mariadb python36 python3-devel graphviz-devel && \
+RUN dnf install -y gcc redhat-rpm-config make mariadb mariadb-devel python36 python3-devel graphviz-devel && \
     dnf clean all
 
 ADD . /code

--- a/contrib/travis-ci/runtests.sh
+++ b/contrib/travis-ci/runtests.sh
@@ -120,7 +120,7 @@ docker run --rm --name nitrate-testbox ${docker_run_opts[@]} \
     /bin/bash -c "
 set -e
 
-dnf install -y gcc redhat-rpm-config make mariadb python36 python3-virtualenv \
+dnf install -y gcc redhat-rpm-config make mariadb mariadb-devel python36 python3-virtualenv \
     python3-devel graphviz-devel postgresql-devel
 virtualenv --python=${py_bin} /testenv
 source /testenv/bin/activate

--- a/docker/released/Dockerfile
+++ b/docker/released/Dockerfile
@@ -17,7 +17,7 @@ username and password are 'admin'." \
 # install virtualenv and libraries needed to build the python dependencies
 RUN dnf update -y && \
     dnf install -y gcc python3-devel graphviz-devel \
-    httpd mariadb python3-mod_wsgi && \
+    httpd mariadb python3-mod_wsgi mariadb-devel && \
     dnf clean all
 
 # Download released tarball and extract to /code

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
 ]
 
 extras_require = {
-    'mysql': ['PyMySQL == 0.9.2'],
+    'mysql': ['mysqlclient >= 1.2.3'],
     'pgsql': ['psycopg2 == 2.7.5'],
 
     # Required for tcms.auth.backends.KerberosBackend

--- a/src/tcms/__init__.py
+++ b/src/tcms/__init__.py
@@ -2,15 +2,6 @@
 
 from django.conf import settings
 
-try:
-    import pymysql
-except ImportError:
-    # Database backend is selectable. When another is selected other than
-    # mysql, skip the call in else section.
-    pass
-else:
-    pymysql.install_as_MySQLdb()
-
 if settings.ASYNC_TASK == 'CELERY':
     # This will make sure the app is always imported when
     # Django starts so that shared_task will use this app.

--- a/src/tcms/core/models/fields.py
+++ b/src/tcms/core/models/fields.py
@@ -8,7 +8,7 @@ from django.db.models.fields import BooleanField
 from tcms.core.forms.fields import DurationField as DurationFormField
 
 try:
-    from pymysql.constants import FIELD_TYPE
+    from MySQLdb.constants import FIELD_TYPE
 except ImportError:
     # Refer to tcms/__init__.py for details.
     pass


### PR DESCRIPTION
Last time to replace MySQLdb-python with PyMySQL, that is because the former
package did not work with Python 3. And nowadays, there is a fork frok named
mysqlclient which works with Python 3 and bug fixes. Django also uses this
library for the mysql database backend.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>