### PR TITLE
Allow building image from version branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 version: "2"
 
-# Please note that, this docker-compose is only for test prod docker image.
-# If you would like to launch nitrate for development purpose, please use
+# Please note that, this docker-compose is only for test latest image built
+# from development branch and prod image built from released version.
+# Before launching database and Nitrate images, make sure the image is built by
+# `make image' with proper tag.
+#
+# If you would like to launch Nitrate for development purpose, please use
 # `docker-compose-dev.yml`.
 
 services:
@@ -18,10 +22,7 @@ services:
     depends_on:
     - db
     restart: always
-    build:
-      context: .
-      dockerfile: ./docker/released/Dockerfile
-    image: nitrate/nitrate:4.3
+    image: quay.io/nitrate/nitrate:latest
     ports:
     - "8001:80"
     volumes:

--- a/docker/released/Dockerfile
+++ b/docker/released/Dockerfile
@@ -1,9 +1,5 @@
 FROM registry.fedoraproject.org/fedora:28
-
-ARG VERSION
-
 ENV VCS_URL="https://github.com/Nitrate/Nitrate"
-
 LABEL version="$VERSION" \
       maintainer="Chenxiong Qi <qcxhome@gmail.com>" \
       description="Run Nitrate from a Python virtual environment behind \
@@ -16,28 +12,20 @@ username and password are 'admin'." \
 
 # install virtualenv and libraries needed to build the python dependencies
 RUN dnf update -y && \
-    dnf install -y gcc python3-devel graphviz-devel \
-    httpd mariadb python3-mod_wsgi mariadb-devel && \
+    dnf install -y --setopt=deltarpm=0 --setopt=install_weak_deps=false --setopt=tsflags=nodocs \
+      gcc python3-devel graphviz-devel httpd mariadb python3-mod_wsgi mariadb-devel && \
     dnf clean all
 
-# Download released tarball and extract to /code
-# Note that, archive tarball created by GitHub has prefix Nitrate-${version}.
-# For convenience, move all files under that prefix to /code.
-RUN mkdir /code && \
-    cd /tmp && \
-    curl -L -O ${VCS_URL}/archive/v${VERSION}.tar.gz && \
-    tar xf /tmp/v${VERSION}.tar.gz --directory /code && \
-    mv /code/Nitrate-${VERSION}/* /code && \
-    rm /tmp/v${VERSION}.tar.gz
+WORKDIR /code
+COPY . .
 
 # Hack: easier to set database password via environment variable
-COPY docker/released/product.py /code/src/tcms/settings/product.py
+COPY ./docker/released/product.py src/tcms/settings/product.py
 
 # Create a virtualenv for the application dependencies
 # Using --system-site-packages b/c Apache configuration
 # expects the tcms directory to be there!
-RUN python3 -m venv --system-site-packages /prodenv && \
-    /prodenv/bin/pip install --no-cache-dir /code[mysql]
+RUN python3 -m venv --system-site-packages /prodenv && /prodenv/bin/pip install --no-cache-dir .[mysql]
 
 COPY ./contrib/conf/nitrate-httpd.conf /etc/httpd/conf.d/
 
@@ -54,23 +42,18 @@ RUN sed -i -e 's/^#\(LoadModule mpm_prefork_module .\+\.so\)$/\1/' \
         /etc/httpd/conf.modules.d/00-mpm.conf
 
 # Create and configure directory to hold uploaded files
-RUN mkdir -p /var/nitrate/uploads && \
-    chown apache:apache /var/nitrate/uploads
+RUN mkdir -p /var/nitrate/uploads && chown apache:apache /var/nitrate/uploads
 
 # Install static files
 RUN mkdir -p /usr/share/nitrate/static && \
-    NITRATE_DB_ENGINE=sqlite /prodenv/bin/python /code/src/manage.py \
-        collectstatic --settings=tcms.settings.product --noinput
+    NITRATE_DB_ENGINE=sqlite /prodenv/bin/python src/manage.py collectstatic --settings=tcms.settings.product --noinput
 
 # Install templates
-RUN mkdir -p /usr/share/nitrate/templates && \
-    cp -r /code/src/templates/* /usr/share/nitrate/templates/
+RUN mkdir -p /usr/share/nitrate/templates && cp -r src/templates/* /usr/share/nitrate/templates/
 
 # All the things are installed already. No need to keep source code inside.
-RUN rm -rf /code
-
+# Don't worry, /code was set above as current working directory
+RUN rm -rf *
 EXPOSE 80
-
 VOLUME ["/var/www", "/var/log/httpd", "/var/nitrate/uploads"]
-
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/docker/released/README.md
+++ b/docker/released/README.md
@@ -29,9 +29,24 @@ docker run --link nitrate_db:mariadb -p 80:80 -e NITRATE_DB_NAME=nitrate \
 
 Before logging into Nitrate, you may need to complete following tasks:
 
-- have to create initial users in database manually. This initial user is
-  usually a superuser os that someone can log into Nitrate with this account to
-  manage service.
+- run database migrations if run Nitrate for the first time or there are
+  migrations included in a release.
+
+  ```
+  docker exec -i -t --env DJANGO_SETTINGS_MODULE=tcms.settings.product \
+      container_name /prodenv/bin/django-admin migrate
+  ```
+
+- create initial users in database manually. This initial user is usually a
+  superuser os that someone can log into Nitrate with this account to manage
+  service.
+
+  ```
+  docker exec -i -t --env DJANGO_SETTINGS_MODULE=tcms.settings.product \
+      container_name /prodenv/bin/django-admin createsuperuser \
+      --username admin --email address
+  ```
+
 - Set permissions to default groups. This is optional, but nice-to-have.
 
   ```


### PR DESCRIPTION
docker/released/Dockerfile is refactored to allow building image from version
branch. As a result, once an image is required to be built for a specific
version, just checkout to that version by tag or branch, then `make image'.

Note that, the Dockerfile does not download any tarball from Github anymore.

With this change, it is also possible to build latest image from development
branch. By default, checkout to development branch (currently it is the develop
branch), run `make image', the default tag is 'latest'.

To build an image for a specific version, please remember to set environment
variable IMAGE_VERSION, for example:

    make image IMAGE_VERSION=4.3

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>