### PR TITLE
Parametrize image tag in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 # Please note that, this docker-compose is only for test latest image built
 # from development branch and prod image built from released version.
@@ -22,7 +22,7 @@ services:
     depends_on:
     - db
     restart: always
-    image: quay.io/nitrate/nitrate:latest
+    image: "${DOCKER_ORG:-quay.io/nitrate}/nitrate:${IMAGE_VERSION:-latest}"
     ports:
     - "8001:80"
     volumes:


### PR DESCRIPTION
docker-compose.yml recognizes two environment variables to construct the image
tag, which is same as what are used to `make image'.

* DOCKER_ORG: specifies the prefix of namespace of image in registry. Default
  is quay.io/nitrate.
* IMAGE_VERSION: the image version. Default is latest.

So, if to launch the latest Nitrate image, just simply:

    docker-compose -f docker-compose.yml up

if to launch container of a specific version:

    IMAGE_VERSION=4.3 docker-compose -f docker-compose.yml up

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>