### PR TITLE
Save log action properly if original value is None

### DIFF
--- a/src/tcms/core/ajax.py
+++ b/src/tcms/core/ajax.py
@@ -421,11 +421,15 @@ def update(request):
     if hasattr(targets[0], 'log_action'):
         for t in targets:
             try:
-                t.log_action(
-                    who=request.user,
-                    field=field,
-                    original_value=getattr(t, field),
-                    new_value=value)
+                log_info = {
+                    'who': request.user,
+                    'field': field,
+                    'new_value': value,
+                }
+                original_value = getattr(t, field)
+                if original_value is None:
+                    log_info['original_value'] = 'None'
+                t.log_action(**log_info)
             except (AttributeError, User.DoesNotExist):
                 pass
     objects_update(targets, **{field: value})


### PR DESCRIPTION
This bug was found when adding a parent plan to a plan which does not have one
yet. In this case, original value of plan's parent is None.

The fix sets a word None to log action original value.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>