### PR TITLE
Clean more code accessing HTTPStatus

### DIFF
--- a/src/tcms/testcases/views.py
+++ b/src/tcms/testcases/views.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-import http
 import itertools
 import json
 import logging
 
+from http import HTTPStatus
 from operator import itemgetter, attrgetter
 
 from django.conf import settings
@@ -1765,14 +1765,14 @@ def manage_case_issues(request, case_id, template_name='case/get_issues.html'):
             #        Maybe in future.
             if not self.request.user.has_perm('issuetracker.add_issue'):
                 return JsonResponse({'messages': ['Permission denied.']},
-                                    status=http.HTTPStatus.FORBIDDEN)
+                                    status=HTTPStatus.FORBIDDEN)
 
             request_data = request.GET.copy()
             request_data.update({'case': self.case.pk})
             form = CaseIssueForm(request_data)
             if not form.is_valid():
                 return JsonResponse({'messages': form_error_messags_to_list(form)},
-                                    status=http.HTTPStatus.BAD_REQUEST)
+                                    status=HTTPStatus.BAD_REQUEST)
 
             try:
                 self.case.add_issue(
@@ -1782,19 +1782,19 @@ def manage_case_issues(request, case_id, template_name='case/get_issues.html'):
                     description=form.cleaned_data['description'],
                 )
             except ValidationError as e:
-                return JsonResponse({'messages': e.messages}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({'messages': e.messages}, status=HTTPStatus.BAD_REQUEST)
             except Exception as e:
                 msg = 'Failed to add issue {} to case {}. Error reported: {}'.format(
                     form.cleaned_data['issue_key'], self.case.pk, str(e))
                 logger.exception(msg)
-                return JsonResponse({'messages': [msg]}, status=http.HTTPStatus.BAD_REQUEST)
+                return JsonResponse({'messages': [msg]}, status=HTTPStatus.BAD_REQUEST)
 
             return JsonResponse({'html': self.render()})
 
         def remove(self):
             if not self.request.user.has_perm('issuetracker.delete_issue'):
                 return JsonResponse(
-                    {'messages': ['Permission denied.']}, status=http.HTTPStatus.FORBIDDEN)
+                    {'messages': ['Permission denied.']}, status=HTTPStatus.FORBIDDEN)
 
             class CaseRemoveIssueForm(djforms.Form):
                 handle = djforms.RegexField(r'^remove$')
@@ -1818,12 +1818,12 @@ def manage_case_issues(request, case_id, template_name='case/get_issues.html'):
                     self.case.remove_issue(form.cleaned_data['issue_key'],
                                            form.cleaned_data['case_run'])
                 except (TypeError, ValueError) as e:
-                    return JsonResponse({'messages': [str(e)]}, status=http.HTTPStatus.BAD_REQUEST)
+                    return JsonResponse({'messages': [str(e)]}, status=HTTPStatus.BAD_REQUEST)
                 else:
                     return JsonResponse({'html': self.render()})
             else:
                 return JsonResponse({'messages': form_error_messags_to_list(form)},
-                                    status=http.HTTPStatus.BAD_REQUEST)
+                                    status=HTTPStatus.BAD_REQUEST)
 
     # FIXME: Rewrite these codes for Ajax.Request
     try:
@@ -1831,7 +1831,7 @@ def manage_case_issues(request, case_id, template_name='case/get_issues.html'):
     except Http404:
         return JsonResponse(
             {'messages': [f'Case {case_id} does not exist.']},
-            status=http.HTTPStatus.NOT_FOUND)
+            status=HTTPStatus.NOT_FOUND)
 
     actions = CaseIssueActions(request=request,
                                case=tc,
@@ -1839,7 +1839,7 @@ def manage_case_issues(request, case_id, template_name='case/get_issues.html'):
 
     if not request.GET.get('handle') in actions.__all__:
         return JsonResponse({'messages': ['Unrecognizable actions']},
-                            status=http.HTTPStatus.BAD_REQUEST)
+                            status=HTTPStatus.BAD_REQUEST)
 
     func = getattr(actions, request.GET['handle'])
     return func()

--- a/src/tcms/xmlrpc/filters.py
+++ b/src/tcms/xmlrpc/filters.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import http
 import os
 import sys
 import traceback
 
 from functools import wraps
+from http import HTTPStatus
 from xmlrpc.client import Fault
 
 import django.core.exceptions
@@ -98,11 +98,11 @@ def wrap_exceptions(func):
             return func(*args, **kwargs)
         except django.core.exceptions.PermissionDenied as e:
             # 403 Forbidden
-            fault_code = http.HTTPStatus.FORBIDDEN
+            fault_code = HTTPStatus.FORBIDDEN
             fault_string = str(e)
         except django.db.models.ObjectDoesNotExist as e:
             # 404 Not Found
-            fault_code = http.HTTPStatus.NOT_FOUND
+            fault_code = HTTPStatus.NOT_FOUND
             fault_string = str(e)
         except (django.db.models.FieldDoesNotExist,
                 django.core.exceptions.FieldError,
@@ -111,18 +111,18 @@ def wrap_exceptions(func):
                 ValueError,
                 TypeError) as e:
             # 400 Bad Request
-            fault_code = http.HTTPStatus.BAD_REQUEST
+            fault_code = HTTPStatus.BAD_REQUEST
             fault_string = str(e)
         except django.db.utils.IntegrityError as e:
             # 409 Duplicate
-            fault_code = http.HTTPStatus.CONFLICT
+            fault_code = HTTPStatus.CONFLICT
             fault_string = str(e)
         except NotImplementedError as e:
-            fault_code = http.HTTPStatus.NOT_IMPLEMENTED
+            fault_code = HTTPStatus.NOT_IMPLEMENTED
             fault_string = str(e)
         except Exception as e:
             # 500 Server Error
-            fault_code = http.HTTPStatus.INTERNAL_SERVER_ERROR
+            fault_code = HTTPStatus.INTERNAL_SERVER_ERROR
             fault_string = str(e)
 
         if settings.DEBUG:

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import http
 import json
 import re
 
+from http import HTTPStatus
 from urllib.parse import urlparse, parse_qs
 
 from django import test
@@ -98,8 +98,27 @@ def create_request_user(username=None, password=None):
 class HelperAssertions:
     """Helper assertion methods"""
 
+    def assert200(self, response):
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+
+    def assert301(self, response):
+        self.assertEqual(HTTPStatus.MOVED_PERMANENTLY, response.status_code)
+
+    def assert302(self, response):
+        self.assertEqual(HTTPStatus.FOUND, response.status_code)
+
+    def assert400(self, response):
+        self.assertEqual(HTTPStatus.BAD_REQUEST, response.status_code)
+
+    def assert403(self, response):
+        self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
+
     def assert404(self, response):
-        self.assertEqual(http.HTTPStatus.NOT_FOUND, response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, response.status_code)
+
+    def assert500(self, response):
+        self.assertEqual(
+            HTTPStatus.INTERNAL_SERVER_ERROR, response.status_code)
 
     def assertJsonResponse(self, response, expected, status_code=200):
         self.assertEqual(status_code, response.status_code)

--- a/src/tests/core/test_core.py
+++ b/src/tests/core/test_core.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import http
 import sys
 import unittest
 from mock import patch
@@ -15,7 +14,9 @@ from tcms.core.db import GroupByResult
 from tcms.core.utils import string_to_list
 from tcms.core.task import AsyncTask
 from tcms.core.task import Task
+from tests import HelperAssertions
 from tests.factories import TestPlanFactory
+
 
 PY37 = sys.version_info[:2] == (3, 7)
 
@@ -256,18 +257,18 @@ class GroupByResultLevelTest(unittest.TestCase):
         self.assertEqual(value_leaf_count, 2)
 
 
-class VariousResponsesTest(unittest.TestCase):
+class VariousResponsesTest(HelperAssertions, unittest.TestCase):
     """Test HttpJSONResponse"""
 
     def test_json_response_badrequest(self):
         response = responses.JsonResponseBadRequest({})
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, response.status_code)
+
+        self.assert400(response)
         self.assertEqual(response['Content-Type'], 'application/json')
 
     def test_json_response_servererror(self):
         response = responses.JsonResponseServerError({})
-        self.assertEqual(http.HTTPStatus.INTERNAL_SERVER_ERROR,
-                         response.status_code)
+        self.assert500(response)
         self.assertEqual(response['Content-Type'], 'application/json')
 
 

--- a/src/tests/core/test_views.py
+++ b/src/tests/core/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import http
 import json
+from http import HTTPStatus
 
 from django import test
 from django.contrib.auth.models import User
@@ -19,8 +19,7 @@ from tcms.testcases.forms import TestCase
 from tcms.testplans.models import TestPlan
 from tcms.testruns.models import TestCaseRun
 from tcms.testruns.models import TestCaseRunStatus
-from tests import BaseCaseRun
-from tests import BasePlanCase
+from tests import BaseCaseRun, BasePlanCase
 from tests import remove_perm_from_user
 from tests import user_should_have_perm
 from tests import factories as f
@@ -43,7 +42,7 @@ class TestQuickSearch(BaseCaseRun):
         self.assertRedirects(
             response,
             reverse('plan-get', args=[self.plan.pk]),
-            target_status_code=http.HTTPStatus.MOVED_PERMANENTLY)
+            target_status_code=HTTPStatus.MOVED_PERMANENTLY)
 
     def test_goto_case(self):
         response = self.client.get(
@@ -96,7 +95,7 @@ class TestQuickSearch(BaseCaseRun):
         response = self.client.get(
             self.search_url,
             {'search_type': 'unknown type', 'search_content': self.plan.pk})
-        self.assertEqual(http.HTTPStatus.NOT_FOUND, response.status_code)
+        self.assert404(response)
 
 
 class TestCommentCaseRuns(BaseCaseRun):

--- a/src/tests/testcases/test_views.py
+++ b/src/tests/testcases/test_views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import http
 import json
 import unittest
 import xml.etree.ElementTree
@@ -322,7 +321,7 @@ class TestAddIssueToCase(BasePlanCase):
         }
         response = self.client.get(self.case_issue_url, request_data)
 
-        self.assertEqual(http.HTTPStatus.OK, response.status_code)
+        self.assert200(response)
         self.assertFalse(self.case_1.issues.filter(issue_key='123456').exists())
 
 
@@ -565,7 +564,7 @@ class TestEditCase(BasePlanCase):
     def test_show_edit_page(self):
         self.login_tester()
         response = self.client.get(self.case_edit_url)
-        self.assertEqual(http.HTTPStatus.OK, response.status_code)
+        self.assert200(response)
 
     def test_edit_a_case(self):
         self.login_tester()
@@ -1140,7 +1139,7 @@ class TestAddComponent(BasePlanCase):
             'o_component': [self.component_db.pk],
         })
 
-        self.assertEqual(http.HTTPStatus.OK, resp.status_code)
+        self.assert200(resp)
 
         components = self.case_1.component.all()
         self.assertEqual(1, len(components))
@@ -1153,7 +1152,7 @@ class TestAddComponent(BasePlanCase):
             'o_component': [self.component_db.pk, self.component_cli.pk],
         })
 
-        self.assertEqual(http.HTTPStatus.OK, resp.status_code)
+        self.assert200(resp)
 
         components = self.case_1.component.order_by('name')
         self.assertEqual(2, len(components))
@@ -1170,7 +1169,7 @@ class TestAddComponent(BasePlanCase):
             'o_component': [self.component_doc.pk, self.component_cli.pk],
         })
 
-        self.assertEqual(http.HTTPStatus.OK, resp.status_code)
+        self.assert200(resp)
 
         components = self.case_1.component.order_by('name')
         self.assertEqual(2, len(components))
@@ -1218,7 +1217,7 @@ class TestIssueManagement(BaseCaseRun):
             'case_run': self.case_run_1.pk,
         })
 
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status_code)
+        self.assert400(resp)
         self.assertIn('Missing issue key to delete.', resp.json()['messages'])
 
     def test_bad_case_run_to_remove(self):
@@ -1231,7 +1230,7 @@ class TestIssueManagement(BaseCaseRun):
             'case_run': 1000,
         })
 
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status_code)
+        self.assert400(resp)
         self.assertIn('Test case run does not exists.', resp.json()['messages'])
 
     def test_bad_case_run_case_rel_to_remove(self):
@@ -1244,7 +1243,7 @@ class TestIssueManagement(BaseCaseRun):
             'case_run': self.case_run_2.pk,
         })
 
-        self.assertEqual(http.HTTPStatus.BAD_REQUEST, resp.status_code)
+        self.assert400(resp)
         self.assertIn(
             'Case run {} is not associated with case {}.'.format(
                 self.case_run_2.pk, self.case_1.pk),
@@ -1259,8 +1258,7 @@ class TestIssueManagement(BaseCaseRun):
             'issue_key': '123456',
             'tracker': self.issue_tracker.pk,
         })
-
-        self.assertEqual(http.HTTPStatus.FORBIDDEN, resp.status_code)
+        self.assert403(resp)
 
     def test_no_permission_to_remove(self):
         # Note that, no permission is set for self.tester.
@@ -1270,8 +1268,7 @@ class TestIssueManagement(BaseCaseRun):
             'issue_key': '123456',
             'case_run': self.case_run_1.pk,
         })
-
-        self.assertEqual(http.HTTPStatus.FORBIDDEN, resp.status_code)
+        self.assert403(resp)
 
     def test_add_an_issue(self):
         user_should_have_perm(self.tester, 'issuetracker.add_issue')
@@ -1283,7 +1280,7 @@ class TestIssueManagement(BaseCaseRun):
             'tracker': self.issue_tracker.pk,
         })
 
-        self.assertEqual(http.HTTPStatus.OK, resp.status_code)
+        self.assert200(resp)
 
         added_issue = Issue.objects.filter(
             issue_key='123456', case=self.case_1, case_run__isnull=True
@@ -1306,7 +1303,7 @@ class TestIssueManagement(BaseCaseRun):
             'case': self.case_2.pk,
         })
 
-        self.assertEqual(http.HTTPStatus.OK, resp.status_code)
+        self.assert200(resp)
 
         removed_issue = Issue.objects.filter(
             issue_key='67890', case=self.case_2, case_run__isnull=True

--- a/src/tests/testruns/test_views.py
+++ b/src/tests/testruns/test_views.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import http
 import json
 import os
 
 from datetime import timedelta
+from http import HTTPStatus
 from operator import attrgetter
 
 from mock import patch
@@ -84,13 +84,13 @@ class TestGetRun(BaseCaseRun):
     def test_404_if_non_existing_pk(self):
         url = reverse('run-get', args=[99999999])
         response = self.client.get(url)
-        self.assertEqual(http.HTTPStatus.NOT_FOUND, response.status_code)
+        self.assert404(response)
 
     def test_get_a_run(self):
         url = reverse('run-get', args=[self.test_run.pk])
         response = self.client.get(url)
 
-        self.assertEqual(http.HTTPStatus.OK, response.status_code)
+        self.assert200(response)
 
         for i, case_run in enumerate(
                 (self.case_run_1, self.case_run_2, self.case_run_3), 1):
@@ -517,7 +517,7 @@ class TestStartCloneRunFromRunsSearchPage(CloneRunBaseTest):
                 response,
                 reverse('run-get', args=[cloned_runs[0].pk]))
         else:
-            self.assertEqual(http.HTTPStatus.FOUND, response.status_code)
+            self.assert302(response)
 
         # Currently, runs are not cloned by the order of passed-in runs id. So,
         # ordering by summary to assert equality.
@@ -1121,7 +1121,8 @@ class TestIssueActions(BaseCaseRun):
 
         response = self.client.get(self.run_issues_url, post_data)
         self.assertJsonResponse(
-            response, {'messages': ['Unrecognizable actions']}, http.HTTPStatus.BAD_REQUEST)
+            response, {'messages': ['Unrecognizable actions']},
+            status_code=HTTPStatus.BAD_REQUEST)
 
     def test_remove_issue_from_case_run(self):
         self.login_tester()

--- a/src/tests/xmlrpc/test_filters.py
+++ b/src/tests/xmlrpc/test_filters.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import http
-
 from django.test import TestCase
 
 from tcms.xmlrpc.filters import wrap_exceptions
@@ -16,7 +14,7 @@ class TestFaultCode(XmlrpcAPIBaseTest):
             raise PermissionDenied()
 
         wrapper = wrap_exceptions(raise_exception)
-        self.assertRaisesXmlrpcFault(http.HTTPStatus.FORBIDDEN, wrapper)
+        self.assertXmlrpcFaultForbidden(wrapper)
 
     def test_404(self):
         def raise_exception(*args, **kwargs):
@@ -24,7 +22,7 @@ class TestFaultCode(XmlrpcAPIBaseTest):
             raise ObjectDoesNotExist()
 
         wrapper = wrap_exceptions(raise_exception)
-        self.assertRaisesXmlrpcFault(http.HTTPStatus.NOT_FOUND, wrapper)
+        self.assertXmlrpcFaultNotFound(wrapper)
 
     def test_400(self):
         exceptions = [v for k, v in locals().copy().items() if k != 'self']
@@ -35,7 +33,7 @@ class TestFaultCode(XmlrpcAPIBaseTest):
 
         wrapper = wrap_exceptions(raise_exception)
         for clazz in exceptions:
-            self.assertRaisesXmlrpcFault(http.HTTPStatus.BAD_REQUEST, wrapper, clazz)
+            self.assertXmlrpcFaultBadRequest(wrapper, clazz)
 
     def test_409(self):
         def raise_exception(*args, **kwargs):
@@ -43,21 +41,21 @@ class TestFaultCode(XmlrpcAPIBaseTest):
             raise IntegrityError()
 
         wrapper = wrap_exceptions(raise_exception)
-        self.assertRaisesXmlrpcFault(http.HTTPStatus.CONFLICT, wrapper)
+        self.assertXmlrpcFaultConflict(wrapper)
 
     def test_500(self):
         def raise_exception(*args, **kwargs):
             raise Exception()
 
         wrapper = wrap_exceptions(raise_exception)
-        self.assertRaisesXmlrpcFault(http.HTTPStatus.INTERNAL_SERVER_ERROR, wrapper)
+        self.assertXmlrpcFaultInternalServerError(wrapper)
 
     def test_501(self):
         def raise_exception(*args, **kwargs):
             raise NotImplementedError()
 
         wrapper = wrap_exceptions(raise_exception)
-        self.assertRaisesXmlrpcFault(http.HTTPStatus.NOT_IMPLEMENTED, wrapper)
+        self.assertXmlrpcFaultNotImplemented(wrapper)
 
 
 class TestAutoWrap(TestCase):

--- a/src/tests/xmlrpc/test_product.py
+++ b/src/tests/xmlrpc/test_product.py
@@ -6,10 +6,6 @@ import unittest
 from operator import itemgetter
 
 from django.test import TestCase
-from http.client import BAD_REQUEST
-from http.client import NOT_FOUND
-from http.client import FORBIDDEN
-from http.client import NOT_IMPLEMENTED
 
 from tcms.xmlrpc.api import product
 from tests.factories import ComponentFactory
@@ -43,25 +39,31 @@ class TestCheckCategory(XmlrpcAPIBaseTest):
         self.assertEqual(cat['name'], 'manual')
 
     def test_check_category_with_non_exist_category(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category,
-                                     None, "NonExist", self.product_nitrate.pk)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category, None, "--default--", 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category,
+            None, "NonExist", self.product_nitrate.pk)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category, None, "--default--", 9999)
 
     def test_check_category_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_category, None, "--default--", None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_category, None, "--default--", [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_category, None, "--default--", {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_category, None, "--default--", ())
+        self.assertXmlrpcFaultBadRequest(
+            product.check_category, None, "--default--", None)
+        self.assertXmlrpcFaultBadRequest(
+            product.check_category, None, "--default--", [])
+        self.assertXmlrpcFaultBadRequest(
+            product.check_category, None, "--default--", {})
+        self.assertXmlrpcFaultBadRequest(
+            product.check_category, None, "--default--", ())
 
     def test_no_category_queried_by_special_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category,
-                                     None, None, self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category,
-                                     [], None, self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category,
-                                     {}, None, self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_category,
-                                     (), None, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category, None, None, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category, [], None, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category, {}, None, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_category, (), None, self.product_nitrate.name)
 
 
 class TestCheckComponent(XmlrpcAPIBaseTest):
@@ -81,26 +83,30 @@ class TestCheckComponent(XmlrpcAPIBaseTest):
         self.assertEqual(cat['name'], 'application')
 
     def test_check_component_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, "NonExist", self.product_xmlrpc.pk)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, 'documentation', 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, "NonExist", self.product_xmlrpc.pk)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, 'documentation', 9999)
 
     def test_check_component_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_component, None, 'database', None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_component, None, 'database', [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_component, None, 'database', {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_component, None, 'database', ())
+        self.assertXmlrpcFaultBadRequest(
+            product.check_component, None, 'database', None)
+        self.assertXmlrpcFaultBadRequest(
+            product.check_component, None, 'database', [])
+        self.assertXmlrpcFaultBadRequest(
+            product.check_component, None, 'database', {})
+        self.assertXmlrpcFaultBadRequest(
+            product.check_component, None, 'database', ())
 
     def test_no_component_queried_with_special_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, None, self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, [], self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, {}, self.product_nitrate.name)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_component,
-                                     None, (), self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, None, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, [], self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, {}, self.product_nitrate.name)
+        self.assertXmlrpcFaultNotFound(
+            product.check_component, None, (), self.product_nitrate.name)
 
 
 class TestCheckProduct(XmlrpcAPIBaseTest):
@@ -114,13 +120,13 @@ class TestCheckProduct(XmlrpcAPIBaseTest):
         self.assertEqual(cat['name'], 'Nitrate')
 
     def test_check_product_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.check_product, None, "NonExist")
+        self.assertXmlrpcFaultNotFound(product.check_product, None, "NonExist")
 
     def test_check_product_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_product, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_product, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_product, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.check_product, None, ())
+        self.assertXmlrpcFaultBadRequest(product.check_product, None, None)
+        self.assertXmlrpcFaultBadRequest(product.check_product, None, [])
+        self.assertXmlrpcFaultBadRequest(product.check_product, None, {})
+        self.assertXmlrpcFaultBadRequest(product.check_product, None, ())
 
 
 class TestFilter(XmlrpcAPIBaseTest):
@@ -142,7 +148,8 @@ class TestFilter(XmlrpcAPIBaseTest):
 
     @unittest.skip('TBD, the API needs change to meet this test.')
     def test_filter_by_non_doc_fields(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.filter, None, {'disallow_new': False})
+        self.assertXmlrpcFaultBadRequest(
+            product.filter, None, {'disallow_new': False})
 
 
 class TestFilterCategories(TestCase):
@@ -223,13 +230,13 @@ class TestGet(XmlrpcAPIBaseTest):
         self.assertEqual(cat['name'], "StarCraft")
 
     def test_get_product_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get, None, 9999)
+        self.assertXmlrpcFaultNotFound(product.get, None, 9999)
 
     def test_get_product_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get, None, ())
 
 
 class TestGetBuilds(XmlrpcAPIBaseTest):
@@ -253,14 +260,15 @@ class TestGetBuilds(XmlrpcAPIBaseTest):
         self.assertEqual('unspecified', builds[0]['name'])
 
     def test_get_build_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_builds, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_builds, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_builds, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_builds, None, "Unknown Product")
 
     def test_get_build_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_builds, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_builds, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_builds, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_builds, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_builds, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_builds, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_builds, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_builds, None, ())
 
 
 class TestGetCases(XmlrpcAPIBaseTest):
@@ -292,14 +300,15 @@ class TestGetCases(XmlrpcAPIBaseTest):
         self.assertEqual(len(cases), self.cases_count)
 
     def test_get_case_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_cases, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_cases, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_cases, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_cases, None, "Unknown Product")
 
     def test_get_case_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_cases, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_cases, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_cases, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_cases, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_cases, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_cases, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_cases, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_cases, None, ())
 
 
 class TestGetCategories(XmlrpcAPIBaseTest):
@@ -329,14 +338,15 @@ class TestGetCategories(XmlrpcAPIBaseTest):
         self.assertEqual(cats[2]['name'], 'manual')
 
     def test_get_categories_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_categories, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_categories, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_categories, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_categories, None, "Unknown Product")
 
     def test_get_categories_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_categories, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_categories, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_categories, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_categories, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_categories, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_categories, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_categories, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_categories, None, ())
 
 
 class TestGetCategory(XmlrpcAPIBaseTest):
@@ -351,13 +361,13 @@ class TestGetCategory(XmlrpcAPIBaseTest):
         self.assertEqual(cat['name'], 'manual')
 
     def test_get_category_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_category, None, 9999)
+        self.assertXmlrpcFaultNotFound(product.get_category, None, 9999)
 
     def test_get_category_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_category, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_category, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_category, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_category, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_category, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_category, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_category, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_category, None, ())
 
 
 class TestAddComponent(XmlrpcAPIBaseTest):
@@ -381,12 +391,13 @@ class TestAddComponent(XmlrpcAPIBaseTest):
         self.assertEqual(com['initial_owner'], self.admin.username)
 
     def test_add_component_with_no_perms(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, product.add_component,
-                                     self.staff_request, self.product.pk, "MyComponent")
+        self.assertXmlrpcFaultForbidden(
+            product.add_component,
+            self.staff_request, self.product.pk, "MyComponent")
 
     def test_add_component_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.add_component,
-                                     self.admin_request, 9999, "MyComponent")
+        self.assertXmlrpcFaultNotFound(
+            product.add_component, self.admin_request, 9999, "MyComponent")
 
 
 class TestGetComponent(XmlrpcAPIBaseTest):
@@ -401,13 +412,13 @@ class TestGetComponent(XmlrpcAPIBaseTest):
         self.assertEqual(com['name'], 'application')
 
     def test_get_component_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_component, None, 9999)
+        self.assertXmlrpcFaultNotFound(product.get_component, None, 9999)
 
     def test_get_component_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_component, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_component, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_component, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_component, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_component, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_component, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_component, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_component, None, ())
 
 
 class TestUpdateComponent(XmlrpcAPIBaseTest):
@@ -430,31 +441,37 @@ class TestUpdateComponent(XmlrpcAPIBaseTest):
         self.assertEqual(com['name'], 'Updated')
 
     def test_update_component_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.update_component,
-                                     self.admin_request, 1111, {'name': 'new name'})
+        self.assertXmlrpcFaultNotFound(
+            product.update_component,
+            self.admin_request, 1111, {'name': 'new name'})
 
     def test_update_component_with_no_perms(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, product.update_component,
-                                     self.staff_request, self.component.pk, {})
+        self.assertXmlrpcFaultForbidden(
+            product.update_component,
+            self.staff_request, self.component.pk, {})
 
     def test_update_component_with_special_arg(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, [], {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, {}, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, (), {})
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component, self.admin_request, None, {})
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component, self.admin_request, [], {})
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component, self.admin_request, {}, {})
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component, self.admin_request, (), {})
 
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, self.component.pk, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, self.component.pk, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, self.component.pk, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.update_component,
-                                     self.admin_request, self.component.pk, ())
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component,
+            self.admin_request, self.component.pk, None)
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component,
+            self.admin_request, self.component.pk, [])
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component,
+            self.admin_request, self.component.pk, {})
+        self.assertXmlrpcFaultBadRequest(
+            product.update_component,
+            self.admin_request, self.component.pk, ())
 
 
 class TestGetComponents(XmlrpcAPIBaseTest):
@@ -491,28 +508,31 @@ class TestGetComponents(XmlrpcAPIBaseTest):
         self.assertEqual(expected_names, names)
 
     def test_get_components_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_components, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_components, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_components, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_components, None, "Unknown Product")
 
     def test_get_components_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_components, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_components, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_components, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_components, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_components, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_components, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_components, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_components, None, ())
 
 
 class TestGetEnvironments(XmlrpcAPIBaseTest):
 
     @unittest.skip('No implemented yet.')
     def test_get_environments(self):
-        self.assertRaisesXmlrpcFault(NOT_IMPLEMENTED, product.get_environments, None, None)
+        self.assertXmlrpcFaultNotImplemented(
+            product.get_environments, None, None)
 
 
-class TestGetMilestones(TestCase):
+class TestGetMilestones(XmlrpcAPIBaseTest):
 
     @unittest.skip('No implemented yet.')
     def test_get_milestones(self):
-        self.assertRaisesXmlrpcFault(NOT_IMPLEMENTED, product.get_milestones, None, None)
+        self.assertXmlrpcFaultNotImplemented(
+            product.get_milestones, None, None)
 
 
 class TestGetPlans(XmlrpcAPIBaseTest):
@@ -553,14 +573,15 @@ class TestGetPlans(XmlrpcAPIBaseTest):
         self.assertEqual(plans[1]['name'], 'StarCraft: Start')
 
     def test_get_plans_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_plans, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_plans, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_plans, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_plans, None, "Unknown Product")
 
     def test_get_plans_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_plans, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_plans, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_plans, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_plans, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_plans, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_plans, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_plans, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_plans, None, ())
 
 
 class TestGetRuns(XmlrpcAPIBaseTest):
@@ -596,14 +617,15 @@ class TestGetRuns(XmlrpcAPIBaseTest):
                          'Test run for StarCraft: second one')
 
     def test_get_runs_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_runs, None, 9999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_runs, None, "Unknown Product")
+        self.assertXmlrpcFaultNotFound(product.get_runs, None, 9999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_runs, None, "Unknown Product")
 
     def test_get_runs_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_runs, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_runs, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_runs, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_runs, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_runs, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_runs, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_runs, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_runs, None, ())
 
 
 class TestGetTag(XmlrpcAPIBaseTest):
@@ -620,13 +642,13 @@ class TestGetTag(XmlrpcAPIBaseTest):
         self.assertEqual(tag['name'], "QWER")
 
     def test_get_tag_with_non_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_tag, None, 9999)
+        self.assertXmlrpcFaultNotFound(product.get_tag, None, 9999)
 
     def test_get_tag_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_tag, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_tag, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_tag, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_tag, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_tag, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_tag, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_tag, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_tag, None, ())
 
 
 class TestAddVersion(XmlrpcAPIBaseTest):
@@ -641,10 +663,14 @@ class TestAddVersion(XmlrpcAPIBaseTest):
         cls.staff_request = make_http_request(user=cls.staff)
 
     def test_add_version_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version, self.admin_request, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version, self.admin_request, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version, self.admin_request, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version, self.admin_request, ())
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version, self.admin_request, None)
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version, self.admin_request, [])
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version, self.admin_request, {})
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version, self.admin_request, ())
 
     def test_add_version_with_product_id(self):
         prod = product.add_version(self.admin_request, {
@@ -665,15 +691,17 @@ class TestAddVersion(XmlrpcAPIBaseTest):
 
     def test_add_version_with_non_exist_prod(self):
         non_existing_product_pk = 111111
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.add_version,
-                                     self.admin_request,
-                                     {"product": non_existing_product_pk, "value": "0.1"})
+        self.assertXmlrpcFaultNotFound(
+            product.add_version,
+            self.admin_request,
+            {"product": non_existing_product_pk, "value": "0.1"})
 
     def test_add_version_with_missing_argument(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version,
-                                     self.admin_request, {"product": self.product.pk})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.add_version,
-                                     self.admin_request, {"value": "0.1"})
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version,
+            self.admin_request, {"product": self.product.pk})
+        self.assertXmlrpcFaultBadRequest(
+            product.add_version, self.admin_request, {"value": "0.1"})
 
     def test_add_version_with_extra_unrecognized_field(self):
         new_version = product.add_version(self.admin_request, {
@@ -686,7 +714,8 @@ class TestAddVersion(XmlrpcAPIBaseTest):
         self.assertEqual('New version', new_version['value'])
 
     def test_add_version_with_no_perms(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, product.add_version, self.staff_request, {})
+        self.assertXmlrpcFaultForbidden(
+            product.add_version, self.staff_request, {})
 
 
 class TestGetVersions(XmlrpcAPIBaseTest):
@@ -713,17 +742,18 @@ class TestGetVersions(XmlrpcAPIBaseTest):
         self.assertEqual(self.versions + ['unspecified'], versions)
 
     def test_get_version_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, ())
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, None)
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, [])
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, {})
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, ())
 
     def test_get_version_with_non_exist_prod(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_versions, None, 99999)
-        self.assertRaisesXmlrpcFault(NOT_FOUND, product.get_versions, None, "Missing Product")
+        self.assertXmlrpcFaultNotFound(product.get_versions, None, 99999)
+        self.assertXmlrpcFaultNotFound(
+            product.get_versions, None, "Missing Product")
 
     def test_get_version_with_bad_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, True)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, False)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, '')
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, product.get_versions, None, object)
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, True)
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, False)
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, '')
+        self.assertXmlrpcFaultBadRequest(product.get_versions, None, object)

--- a/src/tests/xmlrpc/test_tag.py
+++ b/src/tests/xmlrpc/test_tag.py
@@ -2,8 +2,6 @@
 
 import operator
 
-from http.client import BAD_REQUEST
-
 from tcms.xmlrpc.api import tag
 from tests.factories import TestTagFactory
 from tests.xmlrpc.utils import XmlrpcAPIBaseTest
@@ -21,15 +19,15 @@ class TestTag(XmlrpcAPIBaseTest):
         cls.tags = [cls.tag_db, cls.tag_fedora, cls.tag_python, cls.tag_tests, cls.tag_xmlrpc]
 
     def test_get_tags_with_no_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, [])
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, {})
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, ())
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, None)
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, [])
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, {})
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, ())
 
     def test_get_tags_with_illgel_args(self):
         bad_args = (1, 0, -1, True, False, '', 'aaaa', object)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, arg)
+            self.assertXmlrpcFaultBadRequest(tag.get_tags, None, arg)
 
     def test_get_tags_with_ids(self):
         test_tag = tag.get_tags(None, {'ids': [self.tag_python.pk,
@@ -60,7 +58,7 @@ class TestTag(XmlrpcAPIBaseTest):
         self.assertEqual(test_tag[2]['name'], 'python')
 
     def test_get_tags_with_non_exist_fields(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, {'tag_id': [1]})
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, {'tag_id': [1]})
 
     def test_get_tags_with_non_list(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, tag.get_tags, None, {'ids': 1})
+        self.assertXmlrpcFaultBadRequest(tag.get_tags, None, {'ids': 1})

--- a/src/tests/xmlrpc/test_testbuild.py
+++ b/src/tests/xmlrpc/test_testbuild.py
@@ -2,10 +2,6 @@
 
 import unittest
 
-from http.client import BAD_REQUEST
-from http.client import FORBIDDEN
-from http.client import NOT_FOUND
-
 from django.test import TestCase
 
 from tcms.xmlrpc.api import build
@@ -37,14 +33,16 @@ class TestBuildCreate(XmlrpcAPIBaseTest):
     def test_build_create_with_no_args(self):
         bad_args = (self.admin_request, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.create, self.admin_request, arg)
+            self.assertXmlrpcFaultBadRequest(
+                build.create, self.admin_request, arg)
 
     def test_build_create_with_no_perms(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, build.create, self.staff_request, {})
+        self.assertXmlrpcFaultForbidden(build.create, self.staff_request, {})
 
     def test_build_create_with_no_required_fields(self):
         def _create(data):
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.create, self.admin_request, data)
+            self.assertXmlrpcFaultBadRequest(
+                build.create, self.admin_request, data)
 
         values = {
             "description": "Test Build",
@@ -66,7 +64,8 @@ class TestBuildCreate(XmlrpcAPIBaseTest):
             "name": "B7",
             "milestone": "aaaaaaaa"
         }
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, build.create, self.admin_request, values)
+        self.assertXmlrpcFaultBadRequest(
+            build.create, self.admin_request, values)
 
     def test_build_create_with_non_exist_product(self):
         values = {
@@ -75,10 +74,12 @@ class TestBuildCreate(XmlrpcAPIBaseTest):
             "description": "Test Build",
             "is_active": False
         }
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.create, self.admin_request, values)
+        self.assertXmlrpcFaultNotFound(
+            build.create, self.admin_request, values)
 
         values['product'] = "AAAAAAAAAA"
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.create, self.admin_request, values)
+        self.assertXmlrpcFaultNotFound(
+            build.create, self.admin_request, values)
 
     def test_build_create_with_chinese(self):
         values = {
@@ -130,35 +131,41 @@ class TestBuildUpdate(XmlrpcAPIBaseTest):
     def test_build_update_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.update, self.admin_request, arg, {})
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.update,
-                                         self.admin_request, self.build_1.pk, {})
+            self.assertXmlrpcFaultBadRequest(
+                build.update, self.admin_request, arg, {})
+            self.assertXmlrpcFaultBadRequest(
+                build.update, self.admin_request, self.build_1.pk, {})
 
     def test_build_update_with_no_perms(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, build.update,
-                                     self.staff_request, self.build_1.pk, {})
+        self.assertXmlrpcFaultForbidden(
+            build.update, self.staff_request, self.build_1.pk, {})
 
     def test_build_update_with_multi_id(self):
         builds = (self.build_1.pk, self.build_2.pk, self.build_3.pk)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, build.update, self.admin_request, builds, {})
+        self.assertXmlrpcFaultBadRequest(
+            build.update, self.admin_request, builds, {})
 
     @unittest.skip('TODO: fix update to make this test pass.')
     def test_build_update_with_non_integer(self):
         bad_args = (True, False, (1,), dict(a=1), -1, 0.7, "", "AA")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.update, self.admin_request, arg, {})
+            self.assertXmlrpcFaultBadRequest(
+                build.update, self.admin_request, arg, {})
 
     def test_build_update_with_non_exist_build(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.update, self.admin_request, 999, {})
+        self.assertXmlrpcFaultNotFound(
+            build.update, self.admin_request, 999, {})
 
     def test_build_update_with_non_exist_product_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.update,
-                                     self.admin_request, self.build_1.pk, {"product": 9999})
+        self.assertXmlrpcFaultNotFound(
+            build.update,
+            self.admin_request, self.build_1.pk, {"product": 9999})
 
     def test_build_update_with_non_exist_product_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.update,
-                                     self.admin_request, self.build_1.pk,
-                                     {"product": "AAAAAAAAAAAAAA"})
+        self.assertXmlrpcFaultNotFound(
+            build.update,
+            self.admin_request, self.build_1.pk, {"product": "AAAAAAAAAAAAAA"}
+        )
 
     def test_build_update(self):
         b = build.update(self.admin_request, self.build_3.pk, {
@@ -183,16 +190,16 @@ class TestBuildGet(XmlrpcAPIBaseTest):
     def test_build_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get, None, arg)
 
     @unittest.skip('TODO: fix get to make this test pass.')
     def test_build_get_with_non_integer(self):
         bad_args = (True, False, (1,), dict(a=1), -1, 0.7, "", "AA")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get, None, arg)
 
     def test_build_get_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.get, None, 9999)
+        self.assertXmlrpcFaultNotFound(build.get, None, 9999)
 
     def test_build_get_with_id(self):
         b = build.get(None, self.build.pk)
@@ -218,16 +225,16 @@ class TestBuildGetCaseRuns(XmlrpcAPIBaseTest):
     def test_build_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get_caseruns, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get_caseruns, None, arg)
 
     @unittest.skip('TODO: fix get_caseruns to make this test pass.')
     def test_build_get_with_non_integer(self):
         bad_args = (True, False, (1,), dict(a=1), -1, 0.7, "", "AA")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get_caseruns, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get_caseruns, None, arg)
 
     def test_build_get_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.get_caseruns, None, 9999)
+        self.assertXmlrpcFaultNotFound(build.get_caseruns, None, 9999)
 
     def test_build_get_with_id(self):
         b = build.get_caseruns(None, self.build.pk)
@@ -251,16 +258,16 @@ class TestBuildGetRuns(XmlrpcAPIBaseTest):
     def test_build_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get_runs, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get_runs, None, arg)
 
     @unittest.skip('TODO: fix get_runs to make this test pass.')
     def test_build_get_with_non_integer(self):
         bad_args = (True, False, (1,), dict(a=1), -1, 0.7, "", "AA")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.get_runs, None, arg)
+            self.assertXmlrpcFaultBadRequest(build.get_runs, None, arg)
 
     def test_build_get_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.get_runs, None, 9999)
+        self.assertXmlrpcFaultNotFound(build.get_runs, None, 9999)
 
     def test_build_get_with_id(self):
         b = build.get_runs(None, self.build.pk)
@@ -290,30 +297,35 @@ class TestBuildCheck(XmlrpcAPIBaseTest):
     def test_build_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.check_build, None, arg, self.product.pk)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.check_build, None, "B5", arg)
+            self.assertXmlrpcFaultBadRequest(
+                build.check_build, None, arg, self.product.pk)
+            self.assertXmlrpcFaultBadRequest(
+                build.check_build, None, "B5", arg)
 
     def test_build_get_with_non_exist_build_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.check_build,
-                                     None, "AAAAAAAAAAAAAA", self.product.pk)
+        self.assertXmlrpcFaultNotFound(
+            build.check_build, None, "AAAAAAAAAAAAAA", self.product.pk)
 
     def test_build_get_with_non_exist_product_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.check_build, None, "B5", 9999999)
+        self.assertXmlrpcFaultNotFound(build.check_build, None, "B5", 9999999)
 
     def test_build_get_with_non_exist_product_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, build.check_build, None, "B5", "AAAAAAAAAAAAAAAA")
+        self.assertXmlrpcFaultNotFound(
+            build.check_build, None, "B5", "AAAAAAAAAAAAAAAA")
 
     @unittest.skip('TODO: fix check_build to make this test pass.')
     def test_build_get_with_empty(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, build.check_build, None, "", self.product.pk)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, build.check_build,
-                                     None, "         ", self.product.pk)
+        self.assertXmlrpcFaultBadRequest(
+            build.check_build, None, "", self.product.pk)
+        self.assertXmlrpcFaultBadRequest(
+            build.check_build, None, "         ", self.product.pk)
 
     @unittest.skip('TODO: fix check_build to make this test pass.')
     def test_build_get_with_illegal_args(self):
         bad_args = (self, 0.7, False, True, 1, -1, 0, (1,), dict(a=1))
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, build.check_build, None, arg, self.product.pk)
+            self.assertXmlrpcFaultBadRequest(
+                build.check_build, None, arg, self.product.pk)
 
     def test_build_get(self):
         b = build.check_build(None, self.build.name, self.product.pk)

--- a/src/tests/xmlrpc/test_testcaseplan.py
+++ b/src/tests/xmlrpc/test_testcaseplan.py
@@ -2,9 +2,6 @@
 
 import unittest
 
-from http.client import BAD_REQUEST
-from http.client import NOT_FOUND
-
 from tcms.xmlrpc.api import testcaseplan
 from tests.factories import TestCaseFactory
 from tests.factories import TestCasePlanFactory
@@ -31,32 +28,40 @@ class TestCasePlanGet(XmlrpcAPIBaseTest):
     def test_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaseplan.get, None, arg, self.plan.pk)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaseplan.get, None, self.case.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.get, None, arg, self.plan.pk)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.get, None, self.case.pk, arg)
 
     def test_get_with_no_exist_case(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.get, None, 10000, self.plan.pk)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.get, None, 10000, self.plan.pk)
 
     def test_get_with_no_exist_plan(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.get, None, self.case.pk, 10000)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.get, None, self.case.pk, 10000)
 
     @unittest.skip('TODO: fix get to make this test pass.')
     def test_get_with_non_integer_case_id(self):
         bad_args = ("A", "1", "", True, False, self, (1,))
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaseplan.get, None, arg, self.plan.pk)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.get, None, arg, self.plan.pk)
 
     @unittest.skip('TODO: fix get to make this test pass.')
     def test_get_with_non_integer_plan_id(self):
         bad_args = ("A", "1", "", True, False, self, (1,))
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaseplan.get, None, self.case.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.get, None, self.case.pk, arg)
 
     def test_get_with_negative_plan_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.get, None, self.case.pk, -1)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.get, None, self.case.pk, -1)
 
     def test_get_with_negative_case_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.get, None, -1, self.plan.pk)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.get, None, -1, self.plan.pk)
 
 
 class TestCasePlanUpdate(XmlrpcAPIBaseTest):
@@ -76,38 +81,42 @@ class TestCasePlanUpdate(XmlrpcAPIBaseTest):
     def test_update_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST,
-                                         testcaseplan.update, None, arg, self.plan.pk, 100)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST,
-                                         testcaseplan.update, None, self.case.pk, arg, 100)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST,
-                                         testcaseplan.update, None, self.case.pk, self.plan.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.update, None, arg, self.plan.pk, 100)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.update, None, self.case.pk, arg, 100)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.update, None, self.case.pk, self.plan.pk, arg)
 
     def test_update_with_no_exist_case(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.update, None, 10000, self.plan.pk, 100)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.update, None, 10000, self.plan.pk, 100)
 
     def test_update_with_no_exist_plan(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.update, None, self.case.pk, 10000, 100)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.update, None, self.case.pk, 10000, 100)
 
     @unittest.skip('TODO: fix update to make this test pass.')
     def test_update_with_non_integer_case_id(self):
         bad_args = ("A", "1", "", True, False, self, (1,))
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST,
-                                         testcaseplan.update, None, arg, self.plan.pk, 100)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.update, None, arg, self.plan.pk, 100)
 
     @unittest.skip('TODO: fix update to make this test pass.')
     def test_update_with_non_integer_plan_id(self):
         bad_args = ("A", "1", "", True, False, self, (1,))
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST,
-                                         testcaseplan.update, None, self.case.pk, arg, 100)
+            self.assertXmlrpcFaultBadRequest(
+                testcaseplan.update, None, self.case.pk, arg, 100)
 
     def test_update_with_negative_plan_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.update, None, self.case.pk, -1, 100)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.update, None, self.case.pk, -1, 100)
 
     def test_update_with_negative_case_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaseplan.update, None, -1, self.plan.pk, 100)
+        self.assertXmlrpcFaultNotFound(
+            testcaseplan.update, None, -1, self.plan.pk, 100)
 
     def test_update_with_non_integer_sortkey(self):
         original_sortkey = self.case_plan.sortkey

--- a/src/tests/xmlrpc/test_testcaserun.py
+++ b/src/tests/xmlrpc/test_testcaserun.py
@@ -2,10 +2,6 @@
 
 import unittest
 
-from http.client import BAD_REQUEST
-from http.client import FORBIDDEN
-from http.client import NOT_FOUND
-from http.client import NOT_IMPLEMENTED
 from datetime import datetime
 
 from tcms.issuetracker.models import Issue
@@ -50,7 +46,8 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
     def test_create_with_no_args(self):
         bad_args = (None, [], {}, (), 1, 0, -1, True, False, '', 'aaaa', object)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.create, self.admin_request, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.create, self.admin_request, arg)
 
     def test_create_with_no_required_fields(self):
         values = [
@@ -74,7 +71,8 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
             },
         ]
         for value in values:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.create, self.admin_request, value)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.create, self.admin_request, value)
 
     def test_create_with_required_fields(self):
         tcr = testcaserun.create(self.admin_request, {
@@ -129,7 +127,8 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
             },
         ]
         for value in values:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.create, self.admin_request, value)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.create, self.admin_request, value)
 
     def test_create_with_chinese(self):
         tcr = testcaserun.create(self.admin_request, {
@@ -185,7 +184,8 @@ class TestCaseRunCreate(XmlrpcAPIBaseTest):
             "sortkey": 2,
             "case_run_status": self.case_run_status.pk,
         }
-        self.assertRaisesXmlrpcFault(FORBIDDEN, testcaserun.create, self.staff_request, values)
+        self.assertXmlrpcFaultForbidden(
+            testcaserun.create, self.staff_request, values)
 
 
 class TestCaseRunAddComment(XmlrpcAPIBaseTest):
@@ -249,7 +249,8 @@ class TestCaseRunAttachIssue(XmlrpcAPIBaseTest):
             tracker_product=cls.tracker_product)
 
     def test_attach_issue_with_no_perm(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, testcaserun.attach_issue, self.staff_request, {})
+        self.assertXmlrpcFaultForbidden(
+            testcaserun.attach_issue, self.staff_request, {})
 
     @unittest.skip('TODO: not implemented yet.')
     def test_attach_issue_with_incorrect_type_value(self):
@@ -270,8 +271,8 @@ class TestCaseRunAttachIssue(XmlrpcAPIBaseTest):
             },
         ]
         for value in values:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_issue,
-                                         self.admin_request, value)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.attach_issue, self.admin_request, value)
 
     def test_attach_issue_with_required_args(self):
         bug = testcaserun.attach_issue(self.admin_request, {
@@ -334,8 +335,7 @@ class TestCaseRunAttachIssue(XmlrpcAPIBaseTest):
             "issue_key": '2',
             "tracker": self.tracker.pk,
         }
-        self.assertRaisesXmlrpcFault(
-            BAD_REQUEST,
+        self.assertXmlrpcFaultBadRequest(
             testcaserun.attach_issue, self.admin_request, value)
 
     def test_attach_issue_with_non_existing_issue_tracker(self):
@@ -344,8 +344,7 @@ class TestCaseRunAttachIssue(XmlrpcAPIBaseTest):
             "issue_key": '2',
             "tracker": 111111111,
         }
-        self.assertRaisesXmlrpcFault(
-            BAD_REQUEST,
+        self.assertXmlrpcFaultBadRequest(
             testcaserun.attach_issue, self.admin_request, value)
 
     def test_attach_issue_with_chinese(self):
@@ -385,18 +384,21 @@ class TestCaseRunAttachLog(XmlrpcAPIBaseTest):
         pass
 
     def test_attach_log_with_not_enough_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_log, None, '', '')
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_log, None, '')
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_log, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_log, None, '', '', '')
+        self.assertXmlrpcFaultBadRequest(testcaserun.attach_log, None, '', '')
+        self.assertXmlrpcFaultBadRequest(testcaserun.attach_log, None, '')
+        self.assertXmlrpcFaultBadRequest(testcaserun.attach_log, None)
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.attach_log, None, '', '', '')
 
     def test_attach_log_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.attach_log, None, 5523533, '', '')
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.attach_log, None, 5523533, '', '')
 
     @unittest.skip('TODO: code should be fixed to make this test pass')
     def test_attach_log_with_invalid_url(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.attach_log,
-                                     None, self.case_run.pk, "UT test logs", 'aaaaaaaaa')
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.attach_log,
+            None, self.case_run.pk, "UT test logs", 'aaaaaaaaa')
 
     def test_attach_log(self):
         url = "http://127.0.0.1/test/test-log.log"
@@ -411,17 +413,20 @@ class TestCaseRunCheckStatus(XmlrpcAPIBaseTest):
     def test_check_status_with_no_args(self):
         bad_args = (None, [], {}, ())
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.check_case_run_status, None, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.check_case_run_status, None, arg)
 
     @unittest.skip('TODO: fix code to make this test pass.')
     def test_check_status_with_empty_name(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.check_case_run_status, None, '')
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.check_case_run_status, None, '')
 
     @unittest.skip('TODO: fix code to make this test pass.')
     def test_check_status_with_non_basestring(self):
         bad_args = (True, False, 1, 0, -1, [1], (1,), dict(a=1), 0.7)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.check_case_run_status, None, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.check_case_run_status, None, arg)
 
     def test_check_status_with_name(self):
         status = testcaserun.check_case_run_status(None, "IDLE")
@@ -430,7 +435,8 @@ class TestCaseRunCheckStatus(XmlrpcAPIBaseTest):
         self.assertEqual(status['name'], "IDLE")
 
     def test_check_status_with_non_exist_name(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.check_case_run_status, None, "ABCDEFG")
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.check_case_run_status, None, "ABCDEFG")
 
 
 class TestCaseRunDetachIssue(XmlrpcAPIBaseTest):
@@ -484,10 +490,11 @@ class TestCaseRunDetachIssue(XmlrpcAPIBaseTest):
     def test_detach_issue_with_no_args(self):
         bad_args = (None, [], {}, ())
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_issue,
-                                         self.admin_request, arg, '12345')
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_issue,
-                                         self.admin_request, self.case_run.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_issue, self.admin_request, arg, '12345')
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_issue,
+                self.admin_request, self.case_run.pk, arg)
 
     def test_detach_issue_with_non_exist_id(self):
         original_links_count = self.case_run.case.issues.count()
@@ -511,14 +518,15 @@ class TestCaseRunDetachIssue(XmlrpcAPIBaseTest):
     def test_detach_issue_with_illegal_args(self):
         bad_args = ("AAAA", ['A', 'B', 'C'], dict(A=1, B=2), True, False, (1, 2, 3, 4), -100)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_issue,
-                                         self.admin_request, arg, self.bz_bug)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_issue,
-                                         self.admin_request, self.case_run.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_issue, self.admin_request, arg, self.bz_bug)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_issue,
+                self.admin_request, self.case_run.pk, arg)
 
     def test_detach_issue_with_no_perm(self):
-        self.assertRaisesXmlrpcFault(
-            FORBIDDEN, testcaserun.detach_issue,
+        self.assertXmlrpcFaultForbidden(
+            testcaserun.detach_issue,
             self.staff_request, self.case_run.pk, self.bz_bug)
 
 
@@ -541,18 +549,20 @@ class TestCaseRunDetachLog(XmlrpcAPIBaseTest):
     def test_detach_log_with_no_args(self):
         bad_args = (None, [], {}, ())
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log,
-                                         None, arg, self.link.pk)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log,
-                                         None, self.case_run.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_log, None, arg, self.link.pk)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_log, None, self.case_run.pk, arg)
 
     def test_detach_log_with_not_enough_args(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log, None, '')
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log, None)
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log, None, '', '', '')
+        self.assertXmlrpcFaultBadRequest(testcaserun.detach_log, None, '')
+        self.assertXmlrpcFaultBadRequest(testcaserun.detach_log, None)
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.detach_log, None, '', '', '')
 
     def test_detach_log_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.detach_log, None, 9999999, self.link.pk)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.detach_log, None, 9999999, self.link.pk)
 
     def test_detach_log_with_non_exist_log(self):
         testcaserun.detach_log(None, self.case_run.pk, 999999999)
@@ -563,10 +573,10 @@ class TestCaseRunDetachLog(XmlrpcAPIBaseTest):
     def test_detach_log_with_invalid_type_args(self):
         bad_args = ("", "AAA", (1,), [1], dict(a=1), True, False)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log,
-                                         None, arg, self.link.pk)
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.detach_log,
-                                         None, self.case_run.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_log, None, arg, self.link.pk)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.detach_log, None, self.case_run.pk, arg)
 
     def test_detach_log(self):
         testcaserun.detach_log(None, self.case_run.pk, self.link.pk)
@@ -598,16 +608,16 @@ class TestCaseRunGet(XmlrpcAPIBaseTest):
     def test_get_with_no_args(self):
         bad_args = (None, [], {}, ())
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get, None, arg)
+            self.assertXmlrpcFaultBadRequest(testcaserun.get, None, arg)
 
     @unittest.skip('TODO: fix function get to make this test pass.')
     def test_get_with_non_integer(self):
         non_integer = (True, False, '', 'aaaa', self, [1], (1,), dict(a=1), 0.7)
         for arg in non_integer:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get, None, arg)
+            self.assertXmlrpcFaultBadRequest(testcaserun.get, None, arg)
 
     def test_get_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get, None, 11111111)
+        self.assertXmlrpcFaultNotFound(testcaserun.get, None, 11111111)
 
     def test_get_with_id(self):
         tcr = testcaserun.get(None, self.case_run.pk)
@@ -636,41 +646,40 @@ class TestCaseRunGetSet(XmlrpcAPIBaseTest):
     def test_get_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_s,
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_s,
                 None, arg, self.case_run.run.pk, self.case_run.build.pk, 0)
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_s,
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_s,
                 None, self.case_run.case.pk, arg, self.case_run.build.pk, 0)
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_s,
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_s,
                 None, self.case_run.case.pk, self.case_run.run.pk, arg, 0)
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_s,
-                None, self.case_run.case.pk, self.case_run.run.pk, self.case_run.build.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_s,
+                None, self.case_run.case.pk, self.case_run.run.pk,
+                self.case_run.build.pk, arg)
 
     def test_get_with_non_exist_run(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_s,
-                                     None, self.case_run.case.pk, 1111111, self.case_run.build.pk,
-                                     0)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.get_s,
+            None, self.case_run.case.pk, 1111111, self.case_run.build.pk, 0)
 
     def test_get_with_non_exist_case(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_s,
-                                     None, 11111111, self.case_run.run.pk, self.case_run.build.pk,
-                                     0)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.get_s,
+            None, 11111111, self.case_run.run.pk, self.case_run.build.pk, 0)
 
     def test_get_with_non_exist_build(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_s,
-                                     None, self.case_run.case.pk, self.case_run.run.pk, 1111111,
-                                     0)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.get_s,
+            None, self.case_run.case.pk, self.case_run.run.pk, 1111111, 0)
 
     def test_get_with_non_exist_env(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_s,
-                                     None,
-                                     self.case_run.case.pk,
-                                     self.case_run.run.pk,
-                                     self.case_run.build.pk,
-                                     999999)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.get_s,
+            None, self.case_run.case.pk, self.case_run.run.pk,
+            self.case_run.build.pk, 999999)
 
     def test_get_with_no_env(self):
         tcr = testcaserun.get_s(None,
@@ -710,15 +719,15 @@ class TestCaseRunGetIssues(XmlrpcAPIBaseTest):
 
     def test_get_issues_with_no_args(self):
         for bad_arg in [None, [], {}, ()]:
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_issues, None, bad_arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_issues, None, bad_arg)
 
     @unittest.skip('TODO: fix function get_issues to make this test pass.')
     def test_get_issues_with_non_integer(self):
         non_integer = (True, False, '', 'aaaa', self, [1], (1,), dict(a=1), 0.7)
         for arg in non_integer:
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_issues, None, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_issues, None, arg)
 
     def test_get_issues_with_non_exist_id(self):
         issues = testcaserun.get_issues(None, 11111111)
@@ -755,15 +764,13 @@ class TestCaseRunGetIssuesSet(XmlrpcAPIBaseTest):
     def test_get_issue_set_with_no_args(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST,
+            self.assertXmlrpcFaultBadRequest(
                 testcaserun.get_issues_s,
                 None, arg, self.case_run.case.pk, self.case_run.build.pk, 0)
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST, testcaserun.get_issues_s,
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_issues_s,
                 None, self.case_run.run.pk, arg, self.case_run.build.pk, 0)
-            self.assertRaisesXmlrpcFault(
-                BAD_REQUEST,
+            self.assertXmlrpcFaultBadRequest(
                 testcaserun.get_issues_s,
                 None, self.case_run.run.pk, self.case_run.case.pk, arg, 0)
 
@@ -771,12 +778,10 @@ class TestCaseRunGetIssuesSet(XmlrpcAPIBaseTest):
     def test_get_issue_set_with_invalid_environment_value(self):
         bad_args = (None, [], (), {})
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get_issues_s,
-                                         None,
-                                         self.case_run.run.pk,
-                                         self.case_run.case.pk,
-                                         self.case_run.build.pk,
-                                         arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_issues_s,
+                None, self.case_run.run.pk, self.case_run.case.pk,
+                self.case_run.build.pk, arg)
 
     def test_get_issue_set_with_non_exist_run(self):
         issues = testcaserun.get_issues_s(
@@ -857,10 +862,12 @@ class TestCaseRunGetStatus(XmlrpcAPIBaseTest):
     def test_get_status_with_no_args(self):
         bad_args = ([], {}, (), "", "AAAA", self)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get_case_run_status, None, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.get_case_run_status, None, arg)
 
     def test_get_status_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_case_run_status, None, 999999)
+        self.assertXmlrpcFaultNotFound(
+            testcaserun.get_case_run_status, None, 999999)
 
     def test_get_status_with_id(self):
         status = testcaserun.get_case_run_status(None, self.status_running.pk)
@@ -869,7 +876,8 @@ class TestCaseRunGetStatus(XmlrpcAPIBaseTest):
         self.assertEqual(status['name'], "RUNNING")
 
     def test_get_status_with_name(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get_case_run_status, None, 'PROPOSED')
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.get_case_run_status, None, 'PROPOSED')
 
 
 @unittest.skip('not implemented yet.')
@@ -886,15 +894,16 @@ class TestCaseRunGetCompletionTimeSet(XmlrpcAPIBaseTest):
 class TestCaseRunGetHistory(XmlrpcAPIBaseTest):
 
     def test_get_history(self):
-        self.assertRaisesXmlrpcFault(NOT_IMPLEMENTED, testcaserun.get_history, None, None)
+        self.assertXmlrpcFaultNotImplemented(
+            testcaserun.get_history, None, None)
 
 
 @unittest.skip('not implemented yet.')
 class TestCaseRunGetHistorySet(XmlrpcAPIBaseTest):
 
     def test_get_history(self):
-        self.assertRaisesXmlrpcFault(NOT_IMPLEMENTED, testcaserun.get_history_s,
-                                     None, None, None, None)
+        self.assertXmlrpcFaultNotImplemented(
+            testcaserun.get_history_s, None, None, None, None)
 
 
 class TestCaseRunGetLogs(XmlrpcAPIBaseTest):
@@ -909,16 +918,16 @@ class TestCaseRunGetLogs(XmlrpcAPIBaseTest):
     def test_get_logs_with_no_args(self):
         bad_args = (None, [], (), {}, "")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get_logs, None, arg)
+            self.assertXmlrpcFaultBadRequest(testcaserun.get_logs, None, arg)
 
     @unittest.skip('TODO: fix method to make this test pass.')
     def test_get_logs_with_non_integer(self):
         bad_args = (True, False, "AAA", 0.7, -1)
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.get_logs, None, arg)
+            self.assertXmlrpcFaultBadRequest(testcaserun.get_logs, None, arg)
 
     def test_get_logs_with_non_exist_id(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, testcaserun.get_logs, None, 99999999)
+        self.assertXmlrpcFaultNotFound(testcaserun.get_logs, None, 99999999)
 
     def test_get_empty_logs(self):
         logs = testcaserun.get_logs(None, self.case_run_2.pk)
@@ -955,10 +964,11 @@ class TestCaseRunUpdate(XmlrpcAPIBaseTest):
     def test_update_with_no_args(self):
         bad_args = (None, [], (), {}, "")
         for arg in bad_args:
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.update,
-                                         self.admin_request, arg, {})
-            self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.update,
-                                         self.admin_request, self.case_run_1.pk, arg)
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.update, self.admin_request, arg, {})
+            self.assertXmlrpcFaultBadRequest(
+                testcaserun.update,
+                self.admin_request, self.case_run_1.pk, arg)
 
     def test_update_with_single_caserun(self):
         tcr = testcaserun.update(self.admin_request, self.case_run_1.pk, {
@@ -997,17 +1007,19 @@ class TestCaseRunUpdate(XmlrpcAPIBaseTest):
         self.assertEqual(tcr[0]['sortkey'], tcr[1]['sortkey'])
 
     def test_update_with_non_exist_build(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.update,
-                                     self.admin_request, self.case_run_1.pk, {"build": 1111111})
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.update,
+            self.admin_request, self.case_run_1.pk, {"build": 1111111})
 
     def test_update_with_non_exist_assignee(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.update,
-                                     self.admin_request, self.case_run_1.pk, {"assignee": 1111111})
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.update,
+            self.admin_request, self.case_run_1.pk, {"assignee": 1111111})
 
     def test_update_with_non_exist_status(self):
-        self.assertRaisesXmlrpcFault(BAD_REQUEST, testcaserun.update,
-                                     self.admin_request, self.case_run_1.pk,
-                                     {"case_run_status": 1111111})
+        self.assertXmlrpcFaultBadRequest(
+            testcaserun.update,
+            self.admin_request, self.case_run_1.pk, {"case_run_status": 1111})
 
     def test_update_by_ignoring_undoced_fields(self):
         case_run = testcaserun.update(self.admin_request, self.case_run_1.pk, {
@@ -1018,5 +1030,6 @@ class TestCaseRunUpdate(XmlrpcAPIBaseTest):
         self.assertEqual('AAAA', case_run[0]['notes'])
 
     def test_update_with_no_perm(self):
-        self.assertRaisesXmlrpcFault(FORBIDDEN, testcaserun.update,
-                                     self.staff_request, self.case_run_1.pk, {"notes": "AAAA"})
+        self.assertXmlrpcFaultForbidden(
+            testcaserun.update,
+            self.staff_request, self.case_run_1.pk, {"notes": "AAAA"})

--- a/src/tests/xmlrpc/test_user.py
+++ b/src/tests/xmlrpc/test_user.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from http.client import FORBIDDEN
-from http.client import NOT_FOUND
-
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -85,7 +82,8 @@ class TestUserGet(XmlrpcAPIBaseTest):
         self.assertEqual(data['email'], test_user.email)
 
     def test_get_not_exist(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, XUser.get, self.http_req, self.http_req.user.pk + 1)
+        self.assertXmlrpcFaultNotFound(
+            XUser.get, self.http_req, self.http_req.user.pk + 1)
 
 
 class TestUserGetMe(TestCase):
@@ -122,12 +120,13 @@ class TestUserJoin(XmlrpcAPIBaseTest):
         self.assertTrue(user_added_to_group, 'User should be added to group.')
 
     def test_join_nonexistent_user(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, XUser.join,
-                                     self.http_req, 'nonexistent user', 'whatever group name')
+        self.assertXmlrpcFaultNotFound(
+            XUser.join,
+            self.http_req, 'nonexistent user', 'whatever group name')
 
     def test_join_nonexistent_group(self):
-        self.assertRaisesXmlrpcFault(NOT_FOUND, XUser.join,
-                                     self.http_req, self.username, 'nonexistent group name')
+        self.assertXmlrpcFaultNotFound(
+            XUser.join, self.http_req, self.username, 'nonexistent group name')
 
 
 class TestUserUpdate(XmlrpcAPIBaseTest):
@@ -163,8 +162,8 @@ class TestUserUpdate(XmlrpcAPIBaseTest):
 
     def test_update_other_missing_permission(self):
         new_values = {'some_attr': 'xxx'}
-        self.assertRaisesXmlrpcFault(FORBIDDEN, XUser.update,
-                                     self.http_req, new_values, self.another_user.pk)
+        self.assertXmlrpcFaultForbidden(
+            XUser.update, self.http_req, new_values, self.another_user.pk)
 
     def test_update_other_with_proper_permission(self):
         user_should_have_perm(self.http_req.user, 'auth.change_user')
@@ -186,12 +185,12 @@ class TestUserUpdate(XmlrpcAPIBaseTest):
         new_password = 'new password'
         user_new_attrs['password'] = new_password
 
-        self.assertRaisesXmlrpcFault(FORBIDDEN, XUser.update,
-                                     self.http_req, user_new_attrs, test_user.pk)
+        self.assertXmlrpcFaultForbidden(
+            XUser.update, self.http_req, user_new_attrs, test_user.pk)
 
         user_new_attrs['old_password'] = 'invalid old password'
-        self.assertRaisesXmlrpcFault(FORBIDDEN, XUser.update,
-                                     self.http_req, user_new_attrs, test_user.pk)
+        self.assertXmlrpcFaultForbidden(
+            XUser.update, self.http_req, user_new_attrs, test_user.pk)
 
         user_new_attrs['old_password'] = test_user.username
         data = XUser.update(self.http_req, user_new_attrs, test_user.pk)

--- a/src/tests/xmlrpc/utils.py
+++ b/src/tests/xmlrpc/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from http import HTTPStatus
 from xmlrpc.client import Fault
 
 from django import test
@@ -35,6 +36,30 @@ class XmlrpcAPIBaseTest(test.TestCase):
         else:
             self.fail('Expect to raise Fault error with faultCode {}, '
                       'but no exception is raised.'.format(faultCode))
+
+    def assertXmlrpcFaultNotFound(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.NOT_FOUND, func, *args, **kwargs)
+
+    def assertXmlrpcFaultBadRequest(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.BAD_REQUEST, func, *args, **kwargs)
+
+    def assertXmlrpcFaultForbidden(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.FORBIDDEN, func, *args, **kwargs)
+
+    def assertXmlrpcFaultNotImplemented(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.NOT_IMPLEMENTED, func, *args, **kwargs)
+
+    def assertXmlrpcFaultConflict(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.CONFLICT, func, *args, **kwargs)
+
+    def assertXmlrpcFaultInternalServerError(self, func, *args, **kwargs):
+        self.assertRaisesXmlrpcFault(
+            HTTPStatus.INTERNAL_SERVER_ERROR, func, *args, **kwargs)
 
 
 class FakeHTTPRequest:


### PR DESCRIPTION
Simplify massive assertions on response status code.

Importing HTTPStatus instead of http.HTTPStatus to shorten lines of
code.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>