### PR TITLE
Remove clean_assignee from XMLRPCNewCaseRunForm

### DIFF
--- a/src/tcms/testruns/forms.py
+++ b/src/tcms/testruns/forms.py
@@ -372,18 +372,6 @@ class XMLRPCNewCaseRunForm(BaseCaseRunForm):
         label='TestCase', queryset=TestCase.objects.all(),
     )
 
-    def clean_assignee(self):
-        data = self.cleaned_data.get('assignee')
-        if not data:
-            if self.cleaned_data.get('case') \
-                    and self.cleaned_data['case'].default_tester_id:
-                data = self.cleaned_data['case'].default_tester
-            elif self.cleaned_data.get('run') \
-                    and self.cleaned_data['run'].default_tester_id:
-                data = self.cleaned_data['run'].default_tester
-
-        return data
-
     def clean_case_text_version(self):
         data = self.cleaned_data.get('case_text_version')
         if not data and self.cleaned_data.get('case'):


### PR DESCRIPTION
clean_assignee does not work as expected since what it does is actually
incorrect. The code creating a test case run via XMLRPC API works
because TestRun.add_case_run sets assignee in the correct way.

Tests are added for testing using test case or test run default tester
as assignee.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>