### PR TITLE
Reduce the size of testbox

### DIFF
--- a/contrib/travis-ci/Dockerfile
+++ b/contrib/travis-ci/Dockerfile
@@ -3,9 +3,6 @@ LABEL maintainer="Chenxiong Qi <qcxhome@gmail.com>" \
       description="Test box for running Nitrate tests. This test box must work with a database image." \
       version="0.2"
 
-# Add code in order to install dependent packages into test environments.
-ADD . /code
-
 # The image has Python 3.7 by default. So, python36 has to be installed explicitly.
 
 RUN dnf update -y && \
@@ -15,7 +12,7 @@ RUN dnf update -y && \
         --setopt=install_weak_deps=false \
         --setopt=tsflags=nodocs \
         gcc redhat-rpm-config make mariadb python36 \
-        python3-devel mariadb-devel postgresql-devel graphviz-devel krb5-devel && \
+        python3-devel mariadb-devel postgresql-devel krb5-devel && \
     dnf clean all
 
 # Container will have two virtual environments created with Python 3.6 and 3.7
@@ -23,14 +20,18 @@ RUN dnf update -y && \
 # Script running inside container is responsible for selecting the required
 # environment by itself.
 
-RUN python3.6 -m venv /testenv-py36 && \
-    /testenv-py36/bin/python -m pip install --upgrade pip && \
-    /testenv-py36/bin/python -m pip install -e /code[tests,async,mysql,pgsql,docs,krbauth] && \
-    python3.7 -m venv /testenv-py37 && \
-    /testenv-py37/bin/python -m pip install --upgrade pip && \
-    /testenv-py37/bin/python -m pip install -e /code[tests,async,mysql,pgsql,docs,krbauth]
+ADD VERSION.txt README.rst setup.py /code/
 
-RUN rm -rf /code
+RUN mkdir /code/src && \
+    python3.6 -m venv /testenv-py36 && \
+    /testenv-py36/bin/python -m pip install --no-cache-dir --upgrade pip && \
+    /testenv-py36/bin/python -m pip install --no-cache-dir -e \
+        /code[tests,async,mysql,pgsql,docs,krbauth] && \
+    python3.7 -m venv /testenv-py37 && \
+    /testenv-py37/bin/python -m pip install --no-cache-dir --upgrade pip && \
+    /testenv-py37/bin/python -m pip install --no-cache-dir -e \
+        /code[tests,async,mysql,pgsql,docs,krbauth] && \
+    rm -r /code
 
 COPY contrib/travis-ci/entrypoint.sh /opt/test-entrypoint.sh
 ENTRYPOINT "/opt/test-entrypoint.sh"


### PR DESCRIPTION
Tries to reduce the size of testbox. No packages are cached by pip. Do
not add whole project directory while building image. Remove an
unnecessary RPM.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>