### PR TITLE
Blank select option should have an empty value

### DIFF
--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -361,6 +361,7 @@ function set_up_choices(elemSelect, values, addBlankOption) {
 
   if (addBlankOption) {
     newElemOption = document.createElement('option');
+    newElemOption.value = '';
     newElemOption.text = '---------';
     elemSelect.add(newElemOption);
   }


### PR DESCRIPTION
This is a regression bug caused by commit bc97bfa.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>