### PR TITLE
Fix load more tests

### DIFF
--- a/src/tcms/testcases/views.py
+++ b/src/tcms/testcases/views.py
@@ -609,7 +609,7 @@ def all(request, template_name="case/all.html"):
 
         # Load more is a POST request, so POST parameters are required only.
         # Remember this for loading more cases with the same as criterias.
-        'search_criterias': request.body,
+        'search_criterias': request.body.decode('utf-8'),
         'total_cases_count': total_cases_count,
     }
     return render(request, template_name, context=context_data)


### PR DESCRIPTION
request.body is a bytestring. For constructing the data passing to
Javascript in the clinet side, it must be converted into str and written
into template.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>