### PR TITLE
Fix failure coverage upload to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 - contrib/travis-ci/testrunner.py --python-ver "$(python -V | sed 's/Python \([0-9]\+\)\.\([0-9]\+\)\.[0-9]\+/py\1\2/')" --django-ver "$DJANGO_REL" --nitrate-db ${NITRATE_DB:-sqlite} src/tests
 after_success:
 - sudo chown travis:travis .coverage
-- sed -i -e s@/code@"$(pwd)"@g .coverage
+- sqlite3 .coverage "UPDATE file SET path = REPLACE(path, '/code', '"$(pwd)"')"
 - coveralls
 notifications:
   email:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ billiard==3.5.0.5
 celery==4.2.0
 certifi==2019.11.28
 chardet==3.0.4
-coverage==4.5.4
+coverage==5.0.1
 defusedxml==0.6.0
 Django==2.2.8
 django-contrib-comments==1.9.1


### PR DESCRIPTION
Use new version of coverage 5.x and hack the results in .coverage which
is a SQLite database file.

The testbox image has been updated with coverage 5.x and pushed to
Quay.io.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>