### PR TITLE
Remove future-breakpoint from devtools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ extras_require = {
         'tox',
         'django-extensions',
         'pygraphviz',
-        'future-breakpoint',
     ],
 
     # Required packages required to run async tasks


### PR DESCRIPTION
This package is not required after Python 2 was dropped.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>