### PR TITLE
Fix location to load django jQuery lib

### DIFF
--- a/src/templates/case/edit.html
+++ b/src/templates/case/edit.html
@@ -16,6 +16,7 @@
 {% block custom_javascript %}
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="/jsi18n/"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectFilter2.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectBox.js" %}"></script>

--- a/src/templates/case/new.html
+++ b/src/templates/case/new.html
@@ -14,6 +14,7 @@
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="/jsi18n/"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectFilter2.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectBox.js" %}"></script>

--- a/src/templates/environment/group_edit.html
+++ b/src/templates/environment/group_edit.html
@@ -11,6 +11,7 @@
 
 {% block custom_javascript %}
 <script type="text/javascript" src="/jsi18n/"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectFilter2.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectBox.js" %}"></script>
@@ -57,7 +58,7 @@ Nitrate.Utils.after_page_load(Nitrate.Management.Environment.Edit.on_load);
 				</td>
 				<td>
 					<div class="selectgroup">
-						<select name="selected_property_ids" multiple="multiple">
+						<select id="id_properties" name="selected_property_ids" multiple="multiple">
 							{% for property in properties %}
 							<option value="{{ property.id }}" {% ifin property selected_properties %}selected{% endifin %}>{{ property.name }}</option>
 							{% endfor %}

--- a/src/templates/plan/edit.html
+++ b/src/templates/plan/edit.html
@@ -17,6 +17,7 @@
 {% block custom_javascript %}
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript">
 Nitrate.Utils.after_page_load(Nitrate.TestPlans.Edit.on_load);
 </script>

--- a/src/templates/plan/get.html
+++ b/src/templates/plan/get.html
@@ -15,6 +15,7 @@
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="/jsi18n/"></script>
 <script type="text/javascript" src="{% static "js/deleconfirm.js" %}"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectFilter2.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/SelectBox.js" %}"></script>

--- a/src/templates/plan/new.html
+++ b/src/templates/plan/new.html
@@ -12,6 +12,7 @@
 
 {% block custom_javascript %}
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 <script type="text/javascript">
 Nitrate.Utils.after_page_load(Nitrate.TestPlans.Create.on_load);

--- a/src/templates/run/edit.html
+++ b/src/templates/run/edit.html
@@ -9,6 +9,7 @@
 {% block custom_javascript %}
 	<script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
 	<script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
+	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 	<script type="text/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 	<script type="text/javascript">
 	Nitrate.Utils.after_page_load(Nitrate.TestRuns.Edit.on_load);

--- a/src/templates/tcms_base.html
+++ b/src/templates/tcms_base.html
@@ -22,7 +22,6 @@
 	</script>
 	<script type="text/javascript" src="{% static "js/lib/jquery.shiftcheckbox.js" %}"></script>
 	<script type="text/javascript" src="{% static "js/tcms_actions.js" %}"></script>
-	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 	{% block custom_javascript %}{% endblock %}
 	<script type="text/javascript">
 	window.__admin_media_prefix__ = "{% static "admin/" %}";


### PR DESCRIPTION
With the last time to fix this location, it causes datatable cannot
loaded properly when accessing the Runs tab in a plan page.

This also adds a missing element ID that make the select filter work
again.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>