### PR TITLE
JS: start to test js code with qunit

### DIFF
--- a/src/static/js/testrun_actions.js
+++ b/src/static/js/testrun_actions.js
@@ -827,7 +827,7 @@ function editValue(form, hidebox, selectid, submitid) {
         return true;
       });
 
-      set_up_choices(jQ('#' + selectid)[0], values, 0);
+      setUpChoices(jQ('#' + selectid)[0], values, 0);
     },
     'error': function(jqXHR, textStatus, errorThrown) {
       window.alert("Update values failed");
@@ -924,11 +924,10 @@ function addProperty(run_id,env_group_id) {
     'dataType': 'json',
     'data': {'info_type': 'env_properties', 'env_group_id': env_group_id},
     'success': function (data, textStatus, jqXHR) {
-      let values = data.map(function(o) {
-        return [o.pk, o.fields.name];
-      });
-
-      set_up_choices(jQ('#id_add_env_property')[0], values, 0);
+      setUpChoices(
+        jQ('#id_add_env_property')[0],
+        data.map(function(o) {return [o.pk, o.fields.name];}),
+        0);
     },
     'error': function (jqXHR, textStatus, errorThrown) {
       window.alert("Update properties failed");
@@ -951,11 +950,10 @@ function change_value(env_property_id, selectid) {
     'dataType': 'json',
     'data': {'info_type': 'env_values', 'env_property_id': env_property_id},
     'success': function (data, textStatus, jqXHR) {
-      let values = data.map(function(o) {
-        return [o.pk, o.fields.value];
-      });
-
-      set_up_choices(jQ('#' + selectid)[0], values, 0);
+      setUpChoices(
+        jQ('#' + selectid)[0],
+        data.map(function(o) {return [o.pk, o.fields.value];}),
+        0);
     },
     'error': function (jqXHR, textStatus, errorThrown) {
       window.alert("Update values failed");

--- a/src/tests/js/js-tests.html
+++ b/src/tests/js/js-tests.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Test Nitrate client side scripts</title>
+ 
+  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.9.2.css">
+  <script src="https://code.jquery.com/qunit/qunit-2.9.2.js"></script>
+  <script src="../../static/js/lib/jquery-1.7.2.min.js"></script>
+  <script type="text/javascript" charset="utf-8">
+    jQuery.noConflict();
+    let jQ = jQuery;
+    // Top level namespace
+    window.Nitrate = {};
+  </script>
+  <script src="../../static/js/tcms_actions.js" type="text/javascript"></script>
+  <script src="test-tcms-actions.js" type="text/javascript"></script>
+</head>
+<body>
+ 
+<div id="qunit"></div>
+ 
+</body>
+</html>

--- a/src/tests/js/test-tcms-actions.js
+++ b/src/tests/js/test-tcms-actions.js
@@ -1,0 +1,74 @@
+QUnit.module('tcms-action.js', function () {
+
+  QUnit.module('Test setUpChoices', function() {
+    QUnit.test('simple basic setup', function(assert) {
+      let options = [['1', 'case 1'], ['2', 'case 2'], ['3', 'case 3']];
+      let select = jQ('<select name="test_setup_choices"></select>')[0];
+
+      setUpChoices(select, options, false);
+
+      assert.equal(options.length, select.options.length);
+      for (let i = 0; i < select.options.length; i++) {
+        let addOption = select.options[i];
+        assert.equal(options[i][0], addOption.value);
+        assert.equal(options[i][1], addOption.text);
+      }
+    });
+
+    QUnit.test('add a blank option', function(assert) {
+      let options = [['1', 'case 1']];
+      let select = jQ('<select name="test_setup_choices"></select>')[0];
+
+      setUpChoices(select, options, true);
+
+      let addedOption = select.options[0];
+      assert.equal('', addedOption.value);
+      assert.equal('---------', addedOption.text);
+
+      addedOption = select.options[1];
+      assert.equal('1', addedOption.value);
+      assert.equal('case 1', addedOption.text);
+    });
+
+    QUnit.test('empty options', function(assert) {
+      let select = jQ('<select name="test_setup_choices"></select>')[0];
+      setUpChoices(select, [], false);
+      assert.equal(0, select.options.length);
+    });
+
+    QUnit.test('preserve selected option', function(assert) {
+      let select =
+        jQ('<select name="test_setup_choices">' +
+          '<option value="1">case 1</option>'  +
+          '<option value="2" selected>case 2</option>'  +
+          '</select>')[0];
+
+      setUpChoices(select, [['1', 'preserve option'], ['2', 'case 2']], false);
+
+      assert.equal(2, select.options.length);
+
+      let addedOption = select.options[0];
+      assert.equal('1', addedOption.value);
+      assert.equal('preserve option', addedOption.text);
+      assert.notOk(addedOption.selected);
+
+      addedOption = select.options[1];
+      assert.equal('2', addedOption.value);
+      assert.equal('case 2', addedOption.text);
+      assert.ok(addedOption.selected);
+    });
+
+    QUnit.test('shorten long option text', function (assert) {
+      let select = jQ('<select name="test_setup_choices"></select>')[0];
+      let longText = 'abc'.repeat(SHORT_STRING_LENGTH);
+      setUpChoices(select, [['1', longText]], false);
+
+      let addedOption = select.options[0];
+      assert.equal('1', addedOption.value);
+      assert.equal(splitString(longText, SHORT_STRING_LENGTH), addedOption.text);
+      assert.equal(longText, addedOption.title);
+    });
+  });
+
+});
+


### PR DESCRIPTION
qunit is used by Django to test its JavaScript code. After researching
on qunit, I found out it is so easy to understand and start to write
test code with it and the code can also be organized in a reasonable
structure easily. I'm pretty happy with qunit now. However, followings
are some points to be researched:

* mock jQuery.ajax.
* better run tests from command line in order to integrate it with CI
  process.
* show and inspect JavaScript code coverage.

Better than nothing at this moment. Just open the js-tests.html in a Web
browser and tests will run.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>