### PR TITLE
Simplify Prompt.render

### DIFF
--- a/src/tcms/auth/views.py
+++ b/src/tcms/auth/views.py
@@ -10,7 +10,7 @@ from django.views.decorators.http import require_http_methods
 
 from tcms.auth.forms import RegistrationForm
 from tcms.auth.models import UserActivateKey
-from tcms.core.views import Prompt
+from tcms.core.views import prompt
 
 
 @require_GET
@@ -31,11 +31,10 @@ def register(request, template_name='registration/registration_form.html'):
 
     if (user_pwd_backend_config is None or
             not user_pwd_backend_config.get('ALLOW_REGISTER')):
-        return Prompt.render(
-            request=request,
-            info_type=Prompt.Alert,
-            info='The backend is not allowed to register.',
-            next=request_data.get('next', reverse('nitrate-index'))
+        return prompt.alert(
+            request,
+            'The backend is not allowed to register.',
+            request_data.get('next', reverse('nitrate-index'))
         )
 
     if request.method == 'POST':
@@ -65,11 +64,8 @@ def register(request, template_name='registration/registration_form.html'):
                     msg.append('</ul>')
                     msg = ''.join(msg)
 
-            return Prompt.render(
-                request=request,
-                info_type=Prompt.Info,
-                info=msg,
-                next=request.POST.get('next', reverse('nitrate-index'))
+            return prompt.info(
+                request, msg, request.POST.get('next', reverse('nitrate-index'))
             )
     else:
         form = RegistrationForm()
@@ -89,12 +85,10 @@ def confirm(request, activation_key):
         ak = UserActivateKey.objects.select_related('user')
         ak = ak.get(activation_key=activation_key)
     except UserActivateKey.DoesNotExist:
-        msg = 'This key no longer exist in the database.'
-        return Prompt.render(
-            request=request,
-            info_type=Prompt.Info,
-            info=msg,
-            next=request.GET.get('next', reverse('nitrate-index'))
+        return prompt.info(
+            request,
+            'This key no longer exist in the database.',
+            request.GET.get('next', reverse('nitrate-index'))
         )
 
     # All thing done, start to active the user and use the user login
@@ -105,12 +99,10 @@ def confirm(request, activation_key):
     # login(request, user)
 
     # Response to web browser.
-    return Prompt.render(
-        request=request,
-        info_type=Prompt.Info,
-        info='Your account has been activated successfully, click next link to '
-             're-login.',
-        next=request.GET.get('next', reverse('user-profile-redirect'))
+    return prompt.info(
+        request,
+        'Your account has been activated successfully, click next link to re-login.',
+        request.GET.get('next', reverse('user-profile-redirect'))
     )
 
 

--- a/src/tcms/core/files.py
+++ b/src/tcms/core/files.py
@@ -17,7 +17,7 @@ from django.views import generic
 from django.views.decorators.http import require_GET, require_POST
 from six.moves.urllib_parse import unquote
 
-from tcms.core.views import Prompt
+from tcms.core.views import prompt
 from tcms.testcases.models import TestCase, TestCaseAttachment
 from tcms.testplans.models import TestPlan, TestPlanAttachment
 from tcms.management.models import TestAttachment, TestAttachmentData
@@ -35,12 +35,10 @@ class UploadFileView(PermissionRequiredMixin, generic.View):
         to_case_id = request.POST.get('to_case_id')
 
         if to_plan_id is None and to_case_id is None:
-            return Prompt.render(
-                request=request,
-                info_type=Prompt.Alert,
-                info='Uploading file works with plan or case. Nitrate cannot '
-                     'proceed without plan or case ID.',
-                next='javascript:window.history.go(-1);',
+            return prompt.alert(
+                request,
+                'Uploading file works with plan or case. Nitrate cannot '
+                'proceed without plan or case ID.',
             )
 
         if request.FILES.get('upload_file'):
@@ -49,12 +47,7 @@ class UploadFileView(PermissionRequiredMixin, generic.View):
             try:
                 upload_file.name.encode('utf8')
             except UnicodeEncodeError:
-                return Prompt.render(
-                    request=request,
-                    info_type=Prompt.Alert,
-                    info='Upload File name is not legal.',
-                    next='javascript:window.history.go(-1);',
-                )
+                return prompt.alert(request, 'Upload File name is not legal.')
 
             now = datetime.now()
 
@@ -65,12 +58,10 @@ class UploadFileView(PermissionRequiredMixin, generic.View):
             stored_file_name = smart_str(stored_file_name)
 
             if upload_file.size > settings.MAX_UPLOAD_SIZE:
-                return Prompt.render(
-                    request=request,
-                    info_type=Prompt.Alert,
-                    info=f'You upload entity is too large. Please ensure the file is'
-                         f' less than {settings.MAX_UPLOAD_SIZE} bytes.',
-                    next='javascript:window.history.go(-1);',
+                return prompt.alert(
+                    request,
+                    f'You upload entity is too large. Please ensure the file '
+                    f'is less than {settings.MAX_UPLOAD_SIZE} bytes.'
                 )
 
             # Create the upload directory when it's not exist
@@ -78,13 +69,10 @@ class UploadFileView(PermissionRequiredMixin, generic.View):
                 os.mkdir(settings.FILE_UPLOAD_DIR)
 
             if os.path.exists(stored_file_name):
-                return Prompt.render(
-                    request=request,
-                    info_type=Prompt.Alert,
-                    info=f"File named '{upload_file.name}' already exists in "
-                         f"upload folder, please rename to another name for "
-                         f"solve conflict.",
-                    next='javascript:window.history.go(-1);',
+                return prompt.alert(
+                    request,
+                    f"File named '{upload_file.name}' already exists in upload"
+                    f" folder, please rename to another name for solve conflict.",
                 )
 
             with open(stored_file_name, 'wb+') as f:
@@ -157,12 +145,7 @@ def check_file(request, file_id):
         except IOError:
             msg = 'Cannot read attachment file from server.'
             log.exception(msg)
-            return Prompt.render(
-                request=request,
-                info_type=Prompt.Alert,
-                info=msg,
-                next='javascript:window.history.go(-1);',
-            )
+            return prompt.alert(request, msg)
 
     response = HttpResponse(contents, content_type=str(attachment.mime_type))
     file_name = smart_str(attachment.file_name)

--- a/src/tcms/core/views/__init__.py
+++ b/src/tcms/core/views/__init__.py
@@ -3,5 +3,4 @@
 # flake8: noqa
 
 from tcms.core.views.index import index
-from tcms.core.views.prompt import Prompt
 from tcms.core.views.search import search

--- a/src/tcms/core/views/prompt.py
+++ b/src/tcms/core/views/prompt.py
@@ -1,27 +1,24 @@
 # -*- coding: utf-8 -*-
 # FIXME: Use exception to replace the feature
 
+from django.http import HttpRequest
 from django.shortcuts import render
 
+PROMPT_ALERT = 'alert'
+PROMPT_INFO = 'info'
 
-class Prompt:
-    """Common dialog to prompt to users"""
 
-    Alert = 'alert'
-    Info = 'info'
+def alert(request: HttpRequest, content: str, next_: str = None):
+    return render(request, 'prompt.html', context={
+        'type': PROMPT_ALERT,
+        'info': content,
+        'next': next_
+    })
 
-    def __init__(self, request, info_type=None, info=None, next=None):
-        super().__init__()
-        self.request = request
-        self.info_type = info_type
-        self.info = info
-        self.next = next
 
-    @classmethod
-    def render(cls, request, info_type=None, info=None, next=None):
-        """Generate the html to response"""
-        return render(request, 'prompt.html', context={
-            'type': info_type,
-            'info': info,
-            'next': next
-        })
+def info(request: HttpRequest, content: str, next_: str = None):
+    return render(request, 'prompt.html', context={
+        'type': PROMPT_INFO,
+        'info': content,
+        'next': next_
+    })

--- a/src/tcms/testcases/views.py
+++ b/src/tcms/testcases/views.py
@@ -34,7 +34,7 @@ from tcms.core.raw_sql import RawSQL
 from tcms.core.responses import JsonResponseBadRequest, JsonResponseForbidden
 from tcms.core.utils import DataTableResult
 from tcms.core.utils import form_error_messags_to_list
-from tcms.core.views import Prompt
+from tcms.core.views import prompt
 from tcms.issuetracker.models import IssueTracker
 from tcms.logs.models import TCMSLogModel
 from tcms.management.models import Priority, TestTag
@@ -873,12 +873,11 @@ def get(request, case_id, template_name='case/get.html'):
         try:
             tp = tps.get(pk=plan_id_from_request)
         except TestPlan.DoesNotExist:
-            return Prompt.render(
-                request=request,
-                info_type=Prompt.Info,
-                info='''This case has been removed from the plan, but you
-                          can view the case detail''',
-                next=reverse('case-get', args=[case_id, ]),
+            return prompt.info(
+                request,
+                'This case has been removed from the plan, but you can view '
+                'the case detail',
+                reverse('case-get', args=[case_id])
             )
     else:
         tp = None
@@ -963,10 +962,7 @@ def printable(request, template_name='case/printable.html'):
     case_pks = request.POST.getlist('case')
 
     if not case_pks:
-        return Prompt.render(
-            request=request,
-            info_type=Prompt.Info,
-            info='At least one target is required.')
+        return prompt.info(request, 'At least one target is required.')
 
     repeat = len(case_pks)
     params_sql = ','.join(itertools.repeat('%s', repeat))
@@ -985,10 +981,7 @@ def export(request, template_name='case/export.xml'):
     case_pks = list(map(int, request.POST.getlist('case')))
 
     if not case_pks:
-        return Prompt.render(
-            request=request,
-            info_type=Prompt.Info,
-            info='At least one target is required.')
+        return prompt.info(request, 'At least one target is required.')
 
     context_data = {
         'cases_info': get_exported_cases_and_related_data(case_pks=case_pks),
@@ -1260,12 +1253,7 @@ def clone(request, template_name='case/clone.html'):
     request_data = getattr(request, request.method)
 
     if 'case' not in request_data:
-        return Prompt.render(
-            request=request,
-            info_type=Prompt.Info,
-            info='At least one case is required.',
-            next='javascript:window.history.go(-1)'
-        )
+        return prompt.info(request, 'At least one case is required.')
 
     # Do the clone action
     if request.method == 'POST':
@@ -1321,12 +1309,11 @@ def clone(request, template_name='case/clone.html'):
                     reverse('plan-get', args=[dest_plans[0].pk]))
 
             # Otherwise it will prompt to user the clone action is successful.
-            return Prompt.render(
-                request=request,
-                info_type=Prompt.Info,
-                info='Test case successful to clone, click following link '
-                     'to return to plans page.',
-                next=reverse('plans-all')
+            return prompt.info(
+                request,
+                'Test case successful to clone, click following link to return'
+                ' to plans page.',
+                reverse('plans-all')
             )
     else:
         selected_cases = get_selected_testcases(request)

--- a/src/templates/prompt.html
+++ b/src/templates/prompt.html
@@ -9,12 +9,12 @@
 <link rel="stylesheet" type="text/css" href="{% static "style/print.css" %}" media="print" />
 {% endblock %}
 
-{% block custom_javascript %}
-<script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
-<script type="text/javascript">
-Nitrate.Utils.after_page_load(Nitrate.TestPlans.List.on_load);
-</script>
-{% endblock %}
+{#{% block custom_javascript %}#}
+{#<script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>#}
+{#<script type="text/javascript">#}
+{#Nitrate.Utils.after_page_load(Nitrate.TestPlans.List.on_load);#}
+{#</script>#}
+{#{% endblock %}#}
 
 {% block contents %}
 
@@ -26,9 +26,9 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.List.on_load);
 		<p style="font-size:24px; font-weight:bold; margin:0; padding: 70px 0 30px 0; color:#000000; height:32px; line-height:32px; text-align:center; ">{{ info|safe }}</p>
 		<div style=" text-align:center; font-size:14px;">
 			{% if next %}
-				<a href="{{ next }}">Continue</a>
-				{% else %}
-				<input type="button" value="Return" onclick="javascript:history.go(-1)" style="padding-left:10px; padding-right:10px; cursor:pointer;" />
+			<a href="{{ next }}">Continue</a>
+			{% else %}
+			<input type="button" value="Return" onclick="window.history.go(-1)" style="padding-left:10px; padding-right:10px; cursor:pointer;" />
 			{% endif %}
 		</div>
 	</div>

--- a/src/tests/core/test_files.py
+++ b/src/tests/core/test_files.py
@@ -395,7 +395,7 @@ class TestCheckFile(BasePlanCase):
             resp = self.client.get(reverse('check-file', args=[self.file_deleted.pk]))
         self.assert404(resp)
 
-    @patch('tcms.core.views.Prompt.render')
+    @patch('tcms.core.views.prompt.render')
     def test_fail_to_read_file_content(self, render):
         # Following mock on the builtin open function will affect all calls to
         # it, so this test has to patch Prompt.render to return a response
@@ -417,3 +417,4 @@ class TestCheckFile(BasePlanCase):
                 fh = mock_open.return_value.__enter__.return_value
                 fh.read.side_effect = IOError('io error')
                 resp = self.client.get(url)
+                self.assertContains(resp, 'Cannot read file')


### PR DESCRIPTION
The prompt render is reimplemented in a much simpler way by providing
two functions for different levels. The code Prompt.render are updated
with the new functions accordingly.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

Relative to #449 