### PR TITLE
Upgrade celery to 4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ extras_require = {
 
     # Required packages required to run async tasks
     'async': [
-        'celery == 4.2.0',
+        'celery == 4.4.2',
     ],
 
     'multiauth': [

--- a/src/tests/core/test_core.py
+++ b/src/tests/core/test_core.py
@@ -328,8 +328,6 @@ class TestAsyncTask(unittest.TestCase):
             self.assertTrue(thread.daemon)
             thread.start.assert_called_once()
 
-    @unittest.skipIf(PY37, 'Celery<4.3 does not work with Python 3.7. '
-                           'Waiting for 4.3 to be released.')
     @patch('celery.shared_task')
     def test_uses_celery(self, shared_task):
         with patch.object(settings, 'ASYNC_TASK', new=AsyncTask.CELERY.value):


### PR DESCRIPTION
Fixes #457

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

At this moment, version 4.3 is an old version. So, just skip it and upgrade to version 4.4.