### PR TITLE
JS: abstract jQuery.ajax calls

### DIFF
--- a/src/static/js/advance_search.js
+++ b/src/static/js/advance_search.js
@@ -3,12 +3,11 @@ function getProdRelatedObj(prodIDs, target, targetID) {
     prodIDs = [prodIDs];
   }
   // Separator , used to join/split values
-  jQ.ajax({
+  getRequest({
     url: '/ajax/get-prod-relate-obj/',
-    dataType: 'json',
     data: {'p_ids': prodIDs.join(','), 'target': target, 'sep': ','},
-    success: function(res){
-      buildOptions(res, targetID);
+    success: function(data){
+      buildOptions(data, targetID);
     }
   });
 }

--- a/src/static/js/deleconfirm.js
+++ b/src/static/js/deleconfirm.js
@@ -3,17 +3,12 @@ function deleConfirm(attachment_id, home, plan_id) {
     return false;
   }
 
-  jQ.ajax({
+  postRequest({
     url: '/management/deletefile/',
-    type: 'POST',
-    dataType: 'json',
     data: {file_id: attachment_id, from_plan: plan_id},
-    success: function(data, textStatus, jqXHR) {
+    success: function() {
       jQ('#' + attachment_id).remove();
       jQ('#attachment_count').text(parseInt(jQ('#attachment_count').text()) - 1);
     },
-    error: function (jqXHR, textStatus, errorThrown) {
-      window.alert(jqXHR.responseJSON.message);
-    }
   });
 }

--- a/src/static/js/profiles.js
+++ b/src/static/js/profiles.js
@@ -34,20 +34,6 @@ Nitrate.Profiles.Bookmarks.on_load = function() {
       return false;
     }
 
-    jQ.ajax(this.action, {
-      type: this.method,
-      data: parameters,
-      dataType: 'json',
-      traditional: true,
-      success: function () {
-        // using location.reload will cause firefox(tested) remember the checking status
-        window.location = window.location;
-      },
-      statusCode: {
-        400: function (xhr) {
-          json_failure(xhr);
-        }
-      }
-    });
+    postRequest({url: this.action, data: parameters, traditional: true});
   });
 };

--- a/src/tcms/comments/views.py
+++ b/src/tcms/comments/views.py
@@ -5,7 +5,6 @@ import logging
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import JsonResponse
-from django.shortcuts import render
 from django.views import generic
 from django.views.decorators.http import require_POST
 
@@ -27,8 +26,10 @@ def post(request, template_name='comments/comments.html'):
         target, _ = post_comment(
             data, request.user, request.META.get('REMOTE_ADDR'))
     except InvalidCommentPostRequest as e:
-        target = e.target
-    return render(request, template_name, context={'object': target})
+        msg = f'Fail to add comment to object {e.target}'
+        log.exception(msg)
+        return JsonResponseBadRequest({'message': msg})
+    return JsonResponse({})
 
 
 class DeleteCommentView(PermissionRequiredMixin, generic.View):

--- a/src/templates/case/get_issues.html
+++ b/src/templates/case/get_issues.html
@@ -1,4 +1,4 @@
-<table id='issues' count='{{ test_case.get_issues.count }}' class="list" cellpadding="0" cellspacing="0" width="100%">
+<table id='issuelist' count='{{ test_case.get_issues.count }}' class="list" cellpadding="0" cellspacing="0" width="100%">
 	<tr>
 		<th class="widthID">Case Run ID</th>
 		<th class="widthID">Run ID</th>

--- a/src/tests/test_comments.py
+++ b/src/tests/test_comments.py
@@ -12,7 +12,7 @@ from tcms.comments.models import add_comment
 from tests import factories as f, user_should_have_perm, HelperAssertions
 
 
-class TestPostComment(test.TestCase):
+class TestPostComment(HelperAssertions, test.TestCase):
     """Test post comments"""
 
     @classmethod
@@ -68,11 +68,7 @@ class TestPostComment(test.TestCase):
     def test_still_response_comments_even_if_fail_to_add_one(self):
         self.client.login(username=self.tester.username, password='password')
         response = self._post_comment('comment' * 2000)
-        self.assertContains(
-            response,
-            '<ul class="ul-no-format comment"></ul>',
-            html=True
-        )
+        self.assert400(response)
 
 
 class TestDeleteComment(HelperAssertions, test.TestCase):


### PR DESCRIPTION
There are two kinds of jQuery.ajax calls. One is to make a JSON request
which expects the server side responses data in JSON format. And another
one is to just make a normal HTTP request and server responses a piece
of HTML. These calls are abstracted into two dedicated functions which
contains some default values and behavior, which simpifies the original
calls to jQuery.ajax.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

Fixes #604 