### PR TITLE
Avoid submitting issue key when press enter

### DIFF
--- a/src/templates/run/get_case_runs.html
+++ b/src/templates/run/get_case_runs.html
@@ -149,7 +149,7 @@
 </div>
 
 <div id="add-issue-dialog" title="Add issue to case run" style="display: none">
-	<form>
+	<form onsubmit="return false">
 	<fieldset>
 		<div class="bug_type" id="id_issue_tracker">Issue Tracker</div>
 		<select name="issue_tracker_id" id="issue_tracker_id">


### PR DESCRIPTION
This change enforces to press OK button explicitly to add an issue key
to a case run.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>