### PR TITLE
Allow to specify alternative PyPI index to build testbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
   - DJANGO_REL="django>=3.0,<3.1" NITRATE_DB=mariadb
   - DJANGO_REL="django>=3.0,<3.1" NITRATE_DB=postgres
 install: pip install coveralls
-before_script:
-  - docker build -t quay.io/nitrate/testbox:latest -f contrib/travis-ci/Dockerfile .
+before_script: |
+  docker pull quay.io/nitrate/testbox:latest || \
+    docker build -t quay.io/nitrate/testbox:latest -f contrib/travis-ci/Dockerfile .
 script: |
   contrib/travis-ci/testrunner.py \
     --python-ver $TRAVIS_PYTHON_VERSION \

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,9 @@ remove-testbox-image:
 
 .PHONY: testbox-image
 testbox-image: remove-testbox-image
-	@docker build -t $(testbox_image_tag) -f contrib/travis-ci/Dockerfile .
+	@docker build -t $(testbox_image_tag) \
+		$(if $(index_url),--build-arg pypi_index=$(index_url),) \
+		-f contrib/travis-ci/Dockerfile .
 
 .PHONY: push-testbox-image
 push-testbox-image: $(if $(skip_build),,testbox-image)

--- a/contrib/travis-ci/Dockerfile
+++ b/contrib/travis-ci/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="Chenxiong Qi <qcxhome@gmail.com>" \
       description="Test box for running Nitrate tests. This test box must work with a database image." \
       version="0.3"
 
+ARG pypi_index=https://pypi.org/simple
+
 # The image has Python 3.7 by default. So, python36 has to be installed explicitly.
 
 RUN dnf update -y && \
@@ -24,12 +26,16 @@ ADD VERSION.txt README.rst setup.py /code/
 
 RUN mkdir /code/src && \
     python3.6 -m venv /testenv-py36 && \
-    /testenv-py36/bin/python -m pip install --no-cache-dir --upgrade pip && \
-    /testenv-py36/bin/python -m pip install --no-cache-dir -e \
+    /testenv-py36/bin/python -m pip install \
+        --index-url $pypi_index --no-cache-dir --upgrade pip && \
+    /testenv-py36/bin/python -m pip install \
+        --index-url $pypi_index --no-cache-dir -e \
         /code[tests,async,mysql,pgsql,docs,krbauth] && \
     python3.7 -m venv /testenv-py37 && \
-    /testenv-py37/bin/python -m pip install --no-cache-dir --upgrade pip && \
-    /testenv-py37/bin/python -m pip install --no-cache-dir -e \
+    /testenv-py37/bin/python -m pip install \
+        --index-url $pypi_index --no-cache-dir --upgrade pip && \
+    /testenv-py37/bin/python -m pip install \
+        --index-url $pypi_index --no-cache-dir -e \
         /code[tests,async,mysql,pgsql,docs,krbauth] && \
     rm -r /code
 


### PR DESCRIPTION
So, enable the docker-pull again before running tests inside.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>