### PR TITLE
Use new package name psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
 
 extras_require = {
     'mysql': ['mysqlclient >= 1.2.3'],
-    'pgsql': ['psycopg2 == 2.7.5'],
+    'pgsql': ['psycopg2-binary == 2.7.5'],
 
     # Required for tcms.auth.backends.KerberosBackend
     'krbauth': [


### PR DESCRIPTION
This is helpful to suppress warning message emit from psycopg2. As
mentioned in the message, for relative info about the warning, refer to
https://www.psycopg.org/docs/install.html#binary-install-from-pypi

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>