### PR TITLE
JS: Upgrade jquery.shiftcheckbox and enable it

### DIFF
--- a/src/static/js/lib/jquery.shiftcheckbox.js
+++ b/src/static/js/lib/jquery.shiftcheckbox.js
@@ -1,80 +1,196 @@
-/**
- * JQuery shiftcheckbox plugin
+/* ShiftCheckbox jQuery plugin
  *
- * shiftcheckbox provides a simpler and faster way to select/unselect multiple checkboxes within a given range with just two clicks.
- * Inspired from GMail checkbox functionality
+ * Copyright (C) 2011-2012 James Nylen
  *
- * Just call $('.<class-name>').shiftcheckbox() in $(document).ready
+ * Released under MIT license
+ * For details see:
+ * https://github.com/nylen/shiftcheckbox
  *
- * @name shiftcheckbox
- * @type jquery
- * @cat Plugin/Form
- * @return JQuery
- *
- * This plugin is mostly based on the work done by <adityamooley@sanisoft.com>.
- * Changes are made by <cbtchn@gmail.com> by replacing the $.bind with $.live in
- * order to support future binding, as well as the bug fix caused by this change.
+ * Requires jQuery v1.7 or higher.
  */
 
-(function ($) {
-  $.fn.shiftcheckbox = function() {
+(function($) {
+  var ns = '.shiftcheckbox';
 
-    var prevChecked = null;
-    var selectorStr = this.selector;
+  $.fn.shiftcheckbox = function(opts) {
+    opts = $.extend({
+      checkboxSelector : null,
+      selectAll        : null,
+      onChange         : null,
+      ignoreClick      : null
+    }, opts);
 
-    function handleClick(event){
-      var val = this.value;
-      var checkStatus = this.checked;
-      //get the checkbox number which the user has checked
+    if (typeof opts.onChange != 'function') {
+      opts.onChange = function(checked) { };
+    }
 
-      //check whether user has pressed shift
-      if (event.shiftKey) {
-        if (prevChecked != 'null') {
-          //get the current checkbox number
-          var ind = 0, found = 0, currentChecked;
-          currentChecked = getSelected(val);
+    $.fn.scb_changeChecked = function(opts, checked) {
+      this.prop('checked', checked);
+      opts.onChange.call(this, checked);
+      return this;
+    }
 
-          ind = 0;
-          if (currentChecked < prevChecked) {
-            $(selectorStr).each(function(i) {
-              if (ind >= currentChecked && ind <= prevChecked) {
-                // I don't know why I had to manually trigger 'change' event.
-                // Maybe this plugin is drunk, or I am.
-                $(this).attr('checked', checkStatus).trigger('change');
-              }
-              ind++;
-            });
-          } else {
-            $(selectorStr).each(function(i) {
-              if (ind >= prevChecked && ind <= currentChecked) {
-                $(this).attr('checked', checkStatus).trigger('change');
-              }
-              ind++;
-            });
-          }
+    var $containers,
+        $checkboxes,
+        $containersSelectAll,
+        $checkboxesSelectAll,
+        $otherSelectAll,
+        $containersAll,
+        $checkboxesAll;
 
-          prevChecked = currentChecked;
+    if (opts.selectAll) {
+      // We need to set up a "select all" control
+      $containersSelectAll = $(opts.selectAll);
+      if ($containersSelectAll && !$containersSelectAll.length) {
+        $containersSelectAll = false;
+      }
+    }
+
+    if ($containersSelectAll) {
+      $checkboxesSelectAll = $containersSelectAll
+        .filter(':checkbox')
+        .add($containersSelectAll.find(':checkbox'));
+
+      $containersSelectAll = $containersSelectAll.not(':checkbox');
+      $otherSelectAll = $containersSelectAll.filter(function() {
+        return !$(this).find($checkboxesSelectAll).length;
+      });
+      $containersSelectAll = $containersSelectAll.filter(function() {
+        return !!$(this).find($checkboxesSelectAll).length;
+      }).each(function() {
+        $(this).data('childCheckbox', $(this).find($checkboxesSelectAll)[0]);
+      });
+    }
+
+    if (opts.checkboxSelector) {
+
+      // checkboxSelector means that the elements we need to attach handlers to
+      // ($containers) are not actually checkboxes but contain them instead
+
+      $containersAll = this.filter(function() {
+        return !!$(this).find(opts.checkboxSelector).filter(':checkbox').length;
+      }).each(function() {
+        $(this).data('childCheckbox', $(this).find(opts.checkboxSelector).filter(':checkbox')[0]);
+      }).add($containersSelectAll);
+
+      $checkboxesAll = $containersAll.map(function() {
+        return $(this).data('childCheckbox');
+      });
+
+    } else {
+
+      $checkboxesAll = this.filter(':checkbox');
+
+    }
+
+    if ($checkboxesSelectAll && !$checkboxesSelectAll.length) {
+      $checkboxesSelectAll = false;
+    } else {
+      $checkboxesAll = $checkboxesAll.add($checkboxesSelectAll);
+    }
+
+    if ($otherSelectAll && !$otherSelectAll.length) {
+      $otherSelectAll = false;
+    }
+
+    if ($containersAll) {
+      $containers = $containersAll.not($containersSelectAll);
+    }
+    $checkboxes = $checkboxesAll.not($checkboxesSelectAll);
+
+    if (!$checkboxes.length) {
+      return;
+    }
+
+    var lastIndex = -1;
+
+    var checkboxClicked = function(e) {
+      var checked = !!$(this).prop('checked');
+
+      var curIndex = $checkboxes.index(this);
+      if (curIndex < 0) {
+        if ($checkboxesSelectAll.filter(this).length) {
+          $checkboxesAll.scb_changeChecked(opts, checked);
         }
-      } else {
-        if (checkStatus) {
-          prevChecked = getSelected(val);
+        return;
+      }
+
+      if (e.shiftKey && lastIndex != -1) {
+        var di = (curIndex > lastIndex ? 1 : -1);
+        for (var i = lastIndex; i != curIndex; i += di) {
+          $checkboxes.eq(i).scb_changeChecked(opts, checked);
         }
       }
 
-    };
-
-    function getSelected(val) {
-      var ind = 0, found = 0, checkedIndex;
-      $(selectorStr).each(function(i) {
-        if (val == this.value && found != 1) {
-          checkedIndex = ind;
-          found = 1;
+      if ($checkboxesSelectAll) {
+        if (checked && !$checkboxes.not(':checked').length) {
+          $checkboxesSelectAll.scb_changeChecked(opts, true);
+        } else if (!checked) {
+          $checkboxesSelectAll.scb_changeChecked(opts, false);
         }
-        ind++;
-      });
-      return checkedIndex;
+      }
+
+      lastIndex = curIndex;
     };
 
-    $(selectorStr).on("click", handleClick);
+    if ($checkboxesSelectAll) {
+      $checkboxesSelectAll
+        .prop('checked', !$checkboxes.not(':checked').length)
+        .filter(function() {
+          return !$containersAll.find(this).length;
+        }).on('click' + ns, checkboxClicked);
+    }
+
+    if ($otherSelectAll) {
+      $otherSelectAll.on('click' + ns, function() {
+        var checked;
+        if ($checkboxesSelectAll) {
+          checked = !!$checkboxesSelectAll.eq(0).prop('checked');
+        } else {
+          checked = !!$checkboxes.eq(0).prop('checked');
+        }
+        $checkboxesAll.scb_changeChecked(opts, !checked);
+      });
+    }
+
+    if (opts.checkboxSelector) {
+      $containersAll.on('click' + ns, function(e) {
+        if ($(e.target).closest(opts.ignoreClick).length) {
+          return;
+        }
+        var $checkbox = $($(this).data('childCheckbox'));
+        $checkbox.not(e.target).each(function() {
+          var checked = !$checkbox.prop('checked');
+          $(this).scb_changeChecked(opts, checked);
+        });
+
+        $checkbox[0].focus();
+        checkboxClicked.call($checkbox, e);
+
+        // If the user clicked on a label inside the row that points to the
+        // current row's checkbox, cancel the event.
+        var $label = $(e.target).closest('label');
+        var labelFor = $label.attr('for');
+        if (labelFor && labelFor == $checkbox.attr('id')) {
+          if ($label.find($checkbox).length) {
+            // Special case:  The label contains the checkbox.
+            if ($checkbox[0] != e.target) {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        }
+      }).on('mousedown' + ns, function(e) {
+        if (e.shiftKey) {
+          // Prevent selecting text by Shift+click
+          return false;
+        }
+      });
+    } else {
+      $checkboxes.on('click' + ns, checkboxClicked);
+    }
+
+    return this;
   };
 })(jQuery);

--- a/src/static/js/management_actions.js
+++ b/src/static/js/management_actions.js
@@ -146,6 +146,8 @@ Nitrate.Management.Environment.Property = {
         parseInt(jQ(this).parents('.js-one-prop').data('param'))
       );
     });
+
+    jQ('#id_properties_container :checkbox').shiftcheckbox();
   },
 
   /**

--- a/src/static/js/profiles.js
+++ b/src/static/js/profiles.js
@@ -10,13 +10,13 @@ Nitrate.Profiles.Bookmarks.on_load = function () {
       'aLengthMenu': [[10, 20, 50, -1], [10, 20, 50, 'All']],
       'iDisplayLength': 10,
       'bProcessing': true,
-      'oLanguage': {'sEmptyTable': 'No bookmark was found.'}
-    });
-  }
-
-  if (jQ('#id_check_all_bookmark').length) {
-    jQ('#id_check_all_bookmark').on('click', function () {
-      clickedSelectAll(this, jQ('#id_table_bookmark')[0], 'pk');
+      'oLanguage': {'sEmptyTable': 'No bookmark was found.'},
+      'fnDrawCallback': function () {
+        jQ('#id_table_bookmark tbody tr td:nth-child(1)').shiftcheckbox({
+          checkboxSelector: ':checkbox',
+          selectAll: '#id_table_bookmark .js-select-all'
+        });
+      }
     });
   }
 

--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -16,10 +16,6 @@ Nitrate.Utils.after_page_load = function (callback) {
   jQ(window).on('load', callback);
 };
 
-Nitrate.Utils.enableShiftSelectOnCheckbox = function (className) {
-  jQ('.' + className).shiftcheckbox();
-};
-
 Nitrate.Utils.convert = function (argument, data) {
   switch (argument) {
     case 'obj_to_list':
@@ -954,13 +950,6 @@ function getAjaxLoading(id) {
   }
 
   return e;
-}
-
-function clickedSelectAll(checkbox, form, name) {
-  let checkboxes = jQ(form).parent().find('input[name=' + name + ']');
-  for (let i = 0; i < checkboxes.length; i++) {
-    checkboxes[i].checked = checkbox.checked ? true : false;
-  }
 }
 
 /**

--- a/src/static/js/testcase_actions.js
+++ b/src/static/js/testcase_actions.js
@@ -10,16 +10,16 @@ Nitrate.TestCases.AdvanceList.on_load = function () {
   bindCategorySelectorToProduct(true, true, jQ('#id_product')[0], jQ('#id_category')[0]);
   bindComponentSelectorToProduct(true, true, jQ('#id_product')[0], jQ('#id_component')[0]);
 
-  if (jQ('#id_checkbox_all_case').length) {
-    jQ('#id_checkbox_all_case').on('click', function () {
-      clickedSelectAll(this, jQ(this).closest('form')[0], 'case');
-      if (this.checked) {
-        jQ('#case_advance_printable').prop('disabled', false);
-      } else {
-        jQ('#case_advance_printable').prop('disabled', true);
-      }
-    });
-  }
+  jQ('#testcases_table :checkbox').on('change', function () {
+    jQ('#case_advance_printable').prop(
+      'disabled', jQ('#testcases_table tbody :checkbox:checked').length === 0
+    );
+  });
+
+  jQ('#testcases_table tbody tr td:nth-child(2)').shiftcheckbox({
+    checkboxSelector: ':checkbox',
+    selectAll: '#testcases_table .js-select-all'
+  });
 
   jQ('#id_blind_all_link').on('click', function () {
     if (!jQ('div[id^="id_loading_"]').length) {
@@ -56,14 +56,6 @@ Nitrate.TestCases.AdvanceList.on_load = function () {
     });
   });
 
-  jQ('#testcases_table tbody tr input[type=checkbox][name=case]').on('click', function () {
-    if (jQ('input[type=checkbox][name=case]:checked').length) {
-      jQ('#case_advance_printable').prop('disabled', false);
-    } else {
-      jQ('#case_advance_printable').prop('disabled', true);
-    }
-  });
-
   if (window.location.hash === '#expandall') {
     blinddownAllCases();
   }
@@ -80,16 +72,8 @@ Nitrate.TestCases.AdvanceList.on_load = function () {
 Nitrate.TestCases.List.on_load = function () {
   bindCategorySelectorToProduct(true, true, jQ('#id_product')[0], jQ('#id_category')[0]);
   bindComponentSelectorToProduct(true, true, jQ('#id_product')[0], jQ('#id_component')[0]);
-  if (jQ('#id_checkbox_all_case')[0]) {
-    jQ('#id_checkbox_all_case').on('click', function () {
-      clickedSelectAll(this, jQ(this).closest('table')[0], 'case');
-      if (this.checked) {
-        jQ('#case_list_printable').prop('disabled', false);
-      } else {
-        jQ('#case_list_printable').prop('disabled', true);
-      }
-    });
-  }
+
+  /* Event handlers of case expansion/collapse */
 
   jQ('#id_blind_all_link').on('click', function () {
     if (!jQ('div[id^="id_loading_"]').length) {
@@ -109,34 +93,6 @@ Nitrate.TestCases.List.on_load = function () {
         blindupAllCases(element);
       }
     }
-  });
-
-  if (window.location.hash === '#expandall') {
-    blinddownAllCases();
-  }
-
-  jQ('#testcases_table').dataTable({
-    'iDisplayLength': 20,
-    'sPaginationType': 'full_numbers',
-    'bFilter': false,
-    'bLengthChange': false,
-    'aaSorting': [[ 2, 'desc' ]],
-    'bProcessing': true,
-    'bServerSide': true,
-    'sAjaxSource': '/cases/ajax/' + this.window.location.search,
-    'aoColumns': [
-      {'bSortable': false, 'sClass': 'expandable'},
-      {'bSortable': false},
-      {'sType': 'html', 'sClass': 'expandable'},
-      {'sType': 'html', 'sClass': 'expandable'},
-      {'sType': 'html', 'sClass': 'expandable'},
-      {'sClass': 'expandable'},
-      {'sClass': 'expandable'},
-      {'sClass': 'expandable'},
-      {'sClass': 'expandable'},
-      {'sClass': 'expandable'},
-      {'sClass': 'expandable'}
-    ]
   });
 
   jQ('#testcases_table tbody tr td.expandable').on('click', function () {
@@ -159,13 +115,58 @@ Nitrate.TestCases.List.on_load = function () {
     });
   });
 
-  jQ('#testcases_table tbody tr input[type=checkbox][name=case]').on('click', function () {
-    if (jQ('input[type=checkbox][name=case]:checked').length) {
-      jQ('#case_list_printable').prop('disabled', false);
-    } else {
-      jQ('#case_list_printable').prop('disabled', true);
+  if (window.location.hash === '#expandall') {
+    blinddownAllCases();
+  }
+
+  /* Initialize cases search result table and relative controls */
+
+  jQ('#testcases_table').dataTable({
+    'iDisplayLength': 20,
+    'sPaginationType': 'full_numbers',
+    'bFilter': false,
+    'bLengthChange': false,
+    'aaSorting': [[ 2, 'desc' ]],
+    'bProcessing': true,
+    'bServerSide': true,
+    'sAjaxSource': '/cases/ajax/' + this.window.location.search,
+    'aoColumns': [
+      {'bSortable': false, 'sClass': 'expandable'},
+      {'bSortable': false},
+      {'sType': 'html', 'sClass': 'expandable'},
+      {'sType': 'html', 'sClass': 'expandable'},
+      {'sType': 'html', 'sClass': 'expandable'},
+      {'sClass': 'expandable'},
+      {'sClass': 'expandable'},
+      {'sClass': 'expandable'},
+      {'sClass': 'expandable'},
+      {'sClass': 'expandable'},
+      {'sClass': 'expandable'}
+    ],
+    'fnDrawCallback': function () {
+      jQ('#testcases_table tbody tr td:nth-child(2)').shiftcheckbox({
+        checkboxSelector: ':checkbox',
+        selectAll: '#testcases_table .js-select-all'
+      });
+
+      jQ('#testcases_table :checkbox').on('change', function () {
+        let disable = jQ('#testcases_table tbody :checkbox:checked').length === 0;
+        jQ('#case_list_printable').prop('disabled', disable);
+        jQ('#clone_cases').prop('disabled', disable);
+        jQ('#export_selected_cases').prop('disabled', disable);
+      });
     }
   });
+
+  if (jQ('#id_checkbox_all_case')[0]) {
+    jQ('#id_checkbox_all_case').on('click', function () {
+      if (this.checked) {
+        jQ('#case_list_printable').prop('disabled', false);
+      } else {
+        jQ('#case_list_printable').prop('disabled', true);
+      }
+    });
+  }
 
   let listParams = Nitrate.TestCases.List.Param;
   jQ('#case_list_printable').on('click', function () {
@@ -246,8 +247,9 @@ Nitrate.TestCases.Details.on_load = function () {
     });
   });
 
-  jQ('#id_checkbox_all_components').on('click', function () {
-    clickedSelectAll(this, jQ('#id_form_case_component')[0], 'component');
+  jQ('#case-components-table tbody tr td:nth-child(1)').shiftcheckbox({
+    checkboxSelector: ':checkbox',
+    selectAll: '#case-components-table .js-select-all'
   });
 
   jQ('.plan_expandable').on('click', function () {

--- a/src/static/js/testplan_actions.js
+++ b/src/static/js/testplan_actions.js
@@ -493,16 +493,17 @@ Nitrate.TestPlans.Advance_Search_List.on_load = function () {
     bindVersionSelectorToProduct(true);
   }
 
-  if (jQ('#id_check_all_plans').length) {
-    jQ('#id_check_all_plans').on('click', function () {
-      clickedSelectAll(this, jQ('#plans_form')[0], 'plan');
-      if (this.checked) {
-        jQ('#plan_advance_printable').prop('disabled', false);
-      } else {
-        jQ('#plan_advance_printable').prop('disabled', true);
-      }
-    });
-  }
+  jQ('#testplans_table :checkbox').on('change', function () {
+    let disable = jQ('#testplans_table tbody :checkbox:checked').length === 0;
+    jQ('.js-printable-plans').prop('disabled', disable);
+    jQ('.js-clone-plans').prop('disabled', disable);
+    jQ('.js-export-plans').prop('disabled', disable);
+  });
+
+  jQ('#testplans_table tbody tr td:nth-child(1)').shiftcheckbox({
+    checkboxSelector: ':checkbox',
+    selectAll: '#testplans_table .js-select-all'
+  });
 
   if (jQ('#column_add').length) {
     jQ('#column_add').on('change', function () {
@@ -526,14 +527,6 @@ Nitrate.TestPlans.Advance_Search_List.on_load = function () {
       jQ(this).parent().parent().addClass('selection_row');
     } else {
       jQ(this).parent().parent().removeClass('selection_row');
-    }
-  });
-
-  jQ('input[type=checkbox][name=plan]').on('click', function (){
-    if(jQ('input[type=checkbox][name=plan]:checked').length) {
-      jQ('#plan_advance_printable').prop('disabled', false);
-    } else {
-      jQ('#plan_advance_printable').prop('disabled', true);
     }
   });
 
@@ -556,17 +549,6 @@ Nitrate.TestPlans.List.on_load = function () {
     bindVersionSelectorToProduct(true);
   }
 
-  if (jQ('#id_check_all_plans').length) {
-    jQ('#id_check_all_plans').on('click', function () {
-      clickedSelectAll(this, jQ('#plans_form')[0], 'plan');
-      if (this.checked) {
-        jQ('#plan_list_printable').prop('disabled', false);
-      } else {
-        jQ('#plan_list_printable').prop('disabled', true);
-      }
-    });
-  }
-
   if (jQ('#column_add').length) {
     jQ('#column_add').on('change', function () {
       switch(this.value) {
@@ -591,6 +573,16 @@ Nitrate.TestPlans.List.on_load = function () {
       jQ(this).parent().parent().removeClass('selection_row');
     }
   });
+
+  if (jQ('#id_check_all_plans').length) {
+    jQ('#id_check_all_plans').on('click', function () {
+      if (this.checked) {
+        jQ('#plan_list_printable').prop('disabled', false);
+      } else {
+        jQ('#plan_list_printable').prop('disabled', true);
+      }
+    });
+  }
 
   if (jQ('#testplans_table').length) {
     jQ('#testplans_table').dataTable({
@@ -615,16 +607,22 @@ Nitrate.TestPlans.List.on_load = function () {
         {'bSortable': false},
         {'bSortable': false},
         {'bSortable': false}
-      ]
+      ],
+      'fnDrawCallback': function () {
+        jQ('#testplans_table tbody tr td:nth-child(1)').shiftcheckbox({
+          checkboxSelector: ':checkbox',
+          selectAll: '#testplans_table .js-select-all'
+        });
+
+        jQ('#testplans_table :checkbox').on('change', function () {
+          let disable = jQ('#testplans_table tbody :checkbox:checked').length === 0;
+          jQ('.js-printable-plans').prop('disabled', disable);
+          jQ('.js-clone-plans').prop('disabled', disable);
+          jQ('.js-export-plans').prop('disabled', disable);
+        });
+      }
     });
   }
-  jQ('#testplans_table tbody tr input[type=checkbox][name=plan]').on('click', function () {
-    if (jQ('input[type=checkbox][name=plan]:checked').length) {
-      jQ('#plan_list_printable').prop('disabled', false);
-    } else {
-      jQ('#plan_list_printable').prop('disabled', true);
-    }
-  });
 
   jQ('.js-new-plan').on('click', function () {
     window.location = jQ(this).data('param');
@@ -816,13 +814,6 @@ Nitrate.TestPlans.Details = {
       }
     });
 
-    jQ('#id_check_all_runs').on('click', function () {
-      clickedSelectAll(this, jQ('#testruns_table')[0], 'run');
-    });
-
-    Nitrate.Utils.enableShiftSelectOnCheckbox('case_selector');
-    Nitrate.Utils.enableShiftSelectOnCheckbox('run_selector');
-
     Nitrate.TestPlans.Runs.initializeRunTab();
     Nitrate.TestPlans.Runs.bind();
 
@@ -911,13 +902,18 @@ Nitrate.TestPlans.SearchCase.on_load = function () {
       'bFilter': false,
       'aLengthMenu': [[10, 20, 50, -1], [10, 20, 50, 'All']],
       'iDisplayLength': 20,
-      'bProcessing': true
-    });
-  }
+      'bProcessing': true,
+      'fnDrawCallback': function () {
+        jQ('#id_table_cases tbody tr td:nth-child(1)').shiftcheckbox({
+          checkboxSelector: ':checkbox',
+          selectAll: '#id_table_cases .js-select-all'
+        });
 
-  if (jQ('#id_checkbox_all_cases').length) {
-    jQ('#id_checkbox_all_cases').on('click', function () {
-      clickedSelectAll(this, jQ('#id_form_cases')[0], 'case');
+        jQ('#id_table_cases :checkbox').on('change', function () {
+          let disable = jQ('#id_table_cases tbody :checkbox:checked').length === 0;
+          jQ('#add-selected-cases').prop('disabled', disable);
+        });
+      }
     });
   }
 };
@@ -1941,14 +1937,6 @@ function constructPlanDetailsCasesZoneCallback(options) {
       }
     });
 
-    // Observe the check all selectbox
-    if (jQ(form).parent().find('input[value="all"]').length) {
-      let element = jQ(form).parent().find('input[value="all"]')[0];
-      jQ(element).on('click', function () {
-        clickedSelectAll(this, jQ(this).closest('.tab_list')[0], 'case');
-      });
-    }
-
     if (jQ(form).parent().find('.btn_filter').length) {
       let element = jQ(form).parent().find('.btn_filter')[0];
       jQ(element).on('click', function () {
@@ -2110,6 +2098,11 @@ function constructPlanDetailsCasesZone(container, planId, parameters) {
       let casesTable = jQ(casesSection).find('.js-cases-list')[0];
       let navForm = jQ('#js' + type + 'cases-nav-form')[0];
 
+      jQ(casesTable).find('tbody .selector_cell').shiftcheckbox({
+        checkboxSelector: ':checkbox',
+        selectAll: jQ(casesTable).find('.js-select-all')
+      });
+
       jQ('#js' + type + 'case-menu, #js' + type + 'new-case').on('click', function () {
         let params = jQ(this).data('params');
         window.location.href = params[0] + '?from_plan=' + params[1];
@@ -2212,8 +2205,9 @@ function constructPlanComponentsZone(container, parameters, callback) {
         constructPlanComponentsZone(container, p, callback);
       });
 
-      jQ('#id_checkbox_all_component').on('click', function () {
-        clickedSelectAll(this, jQ(this).closest('form')[0], 'component');
+      jQ('#components_table tbody tr td:nth-child(1)').shiftcheckbox({
+        checkboxSelector: ':checkbox',
+        selectAll: '#components_table .js-select-all',
       });
 
       jQ('.js-update-components').click(function () {
@@ -2433,6 +2427,12 @@ Nitrate.TestPlans.Runs = {
             let params = jQ('#run_filter').serializeArray();
             params.forEach(function (param) {
               aoData.push(param);
+            });
+          },
+          'fnDrawCallback': function () {
+            jQ('#testruns_table tbody tr').shiftcheckbox({
+              checkboxSelector: ':checkbox',
+              selectAll: '#testruns_table .js-select-all'
             });
           }
         });

--- a/src/static/js/testrun_actions.js
+++ b/src/static/js/testrun_actions.js
@@ -7,6 +7,7 @@ Nitrate.TestRuns.Execute = {};
 Nitrate.TestRuns.Clone = {};
 Nitrate.TestRuns.ChooseRuns = {};
 Nitrate.TestRuns.AssignCase = {};
+Nitrate.TestRuns.AdvancedSearch = {};
 
 
 function toggleAllCheckBoxes(element, container, name) {
@@ -120,17 +121,31 @@ function removeItem(item, caseEstimatedTime) {
   jQ('#' + item).remove();
 }
 
+function cloneRunsClickHandler() {
+  postToURL(jQ(this).data('param'), Nitrate.Utils.formSerialize(this.form), 'get');
+}
+
+Nitrate.TestRuns.AdvancedSearch.on_load = function () {
+  jQ('#testruns_table tbody tr td:nth-child(1)').shiftcheckbox({
+    checkboxSelector: ':checkbox',
+    selectAll: '#testruns_table .js-select-all',
+  });
+
+  jQ('#testruns_table :checkbox').on('change', function () {
+    jQ('.js-clone-testruns').prop(
+      'disabled', jQ('#testruns_table tbody :checkbox:checked').length === 0
+    );
+  });
+
+  jQ('.js-clone-testruns').on('click', cloneRunsClickHandler);
+}
+
 Nitrate.TestRuns.List.on_load = function () {
   bindVersionSelectorToProduct(true, jQ('#id_product')[0]);
   bindBuildSelectorToProduct(true, jQ('#id_product')[0]);
 
-  Nitrate.Utils.enableShiftSelectOnCheckbox('run_selector');
+  //Nitrate.Utils.enableShiftSelectOnCheckbox('run_selector');
 
-  if (jQ('#testruns_table').length) {
-    jQ('#id_check_all_runs').on('click', function () {
-      clickedSelectAll(this, jQ('#testruns_table')[0], 'run');
-    });
-  }
   if (jQ('#id_people_type').length) {
     jQ('#id_search_people').prop('name', jQ('#id_people_type').val());
     jQ('#id_people_type').on('change', function () {
@@ -150,36 +165,39 @@ Nitrate.TestRuns.List.on_load = function () {
     });
   }
 
-  if (!jQ('#testruns_table').hasClass('js-advance-search-runs')) {
-    jQ('#testruns_table').dataTable({
-      'iDisplayLength': 20,
-      'sPaginationType': 'full_numbers',
-      'bFilter': false,
-      'bLengthChange': false,
-      'aaSorting': [[ 1, 'desc' ]],
-      'bProcessing': true,
-      'bServerSide': true,
-      'sAjaxSource': '/runs/ajax/' + this.window.location.search,
-      'aoColumns': [
-        {'bSortable': false},
-        {'sType': 'numeric'},
-        {'sType': 'html'},
-        {'sType': 'html'},
-        {'sType': 'html'},
-        {'bVisible': false},
-        null,
-        null,
-        null,
-        {'sType': 'numeric', 'bSortable': false},
-        null,
-        {'bSortable': false}
-      ],
-      'oLanguage': {'sEmptyTable': 'No run was found.'}
-    });
-  }
-  jQ('.js-clone-testruns').on('click', function () {
-    postToURL(jQ(this).data('param'), Nitrate.Utils.formSerialize(this.form), 'get');
+  jQ('#testruns_table').dataTable({
+    'iDisplayLength': 20,
+    'sPaginationType': 'full_numbers',
+    'bFilter': false,
+    'bLengthChange': false,
+    'aaSorting': [[ 1, 'desc' ]],
+    'bProcessing': true,
+    'bServerSide': true,
+    'sAjaxSource': '/runs/ajax/' + this.window.location.search,
+    'aoColumns': [
+      {'bSortable': false},
+      {'sType': 'numeric'},
+      {'sType': 'html'},
+      {'sType': 'html'},
+      {'sType': 'html'},
+      {'bVisible': false},
+      null,
+      null,
+      null,
+      {'sType': 'numeric', 'bSortable': false},
+      null,
+      {'bSortable': false}
+    ],
+    'oLanguage': {'sEmptyTable': 'No run was found.'},
+    'fnDrawCallback': function () {
+      jQ('#testruns_table tbody tr td:nth-child(1)').shiftcheckbox({
+        checkboxSelector: ':checkbox',
+        selectAll: '#testruns_table .js-select-all'
+      });
+    }
   });
+
+  jQ('.js-clone-testruns').on('click', cloneRunsClickHandler);
 };
 
 
@@ -338,12 +356,6 @@ Nitrate.TestRuns.Details.on_load = function () {
     jQ('#id_sort').on('click', taggleSortCaseRun);
   }
 
-  jQ('#id_check_all_button').on('click', function () {
-    toggleAllCheckBoxes(this, 'id_table_cases', 'case_run');
-  });
-
-  Nitrate.Utils.enableShiftSelectOnCheckbox('caserun_selector');
-
   if (jQ('#id_check_box_highlight').prop('checked')) {
     jQ('.mine').addClass('highlight');
   }
@@ -441,6 +453,11 @@ Nitrate.TestRuns.Details.on_load = function () {
       'caserunRowContainer': c,
       'expandPaneContainer': cContainer
     });
+  });
+
+  jQ('#id_table_cases tbody .selector_cell').shiftcheckbox({
+    checkboxSelector: ':checkbox',
+    selectAll: '#id_table_cases .js-select-all'
   });
 
   // Auto show the case run contents.

--- a/src/templates/case/common/case_advance_filtered.html
+++ b/src/templates/case/common/case_advance_filtered.html
@@ -22,7 +22,7 @@
 					</a>
 				</th>
 				<th width="20" class="nosort">
-					<input type="checkbox" id="id_checkbox_all_case" title="Select all/Select none">
+					<input type="checkbox" id="id_checkbox_all_case" class="js-select-all" title="Select all/Select none">
 				</th>
 				<th class="widthID"><a href="{{query_url}}&order_by=case_id" title="Sort by Case Id">ID</a></th>
 				<th><a href="{{query_url}}&order_by=summary" title="Sort by Summary">Summary</a></th>

--- a/src/templates/case/common/case_filtered.html
+++ b/src/templates/case/common/case_filtered.html
@@ -4,12 +4,12 @@
 		{#}<span class="tit">{{ test_cases.count }} Cases</span>{#}
 		<span>
 			{% if perms.testcases.add_testcase %}
-			<input type="submit" value="Clone" title="clone selected test plans" />
+			<input type="submit" value="Clone" id="clone_cases" title="clone selected test plans" disabled />
 			{% endif %}
-			<input type="button" disabled="disabled"
+			<input type="button" disabled
                    id="case_list_printable" value="Printable copy"
                    title="Create the printable copy for selected cases." />
-			<input type="button" id="export_selected_cases" value="Export" title="Export the cases for selected cases." />
+			<input type="button" id="export_selected_cases" value="Export" title="Export the cases for selected cases." disabled />
 		</span>
 	</div>
 	<table class="list border-bottom" id="testcases_table" cellpadding="0" cellspacing="0" border="0">
@@ -21,7 +21,7 @@
 					</a>
 				</th>
 				<th width="20" class="nosort">
-					<input type="checkbox" id="id_checkbox_all_case" title="Select all/Select none">
+					<input type="checkbox" id="id_checkbox_all_case" class="js-select-all" title="Select all/Select none">
 				</th>
 				<th class="widthID">ID</th>
 				<th>Summary</th>

--- a/src/templates/case/get_component.html
+++ b/src/templates/case/get_component.html
@@ -1,8 +1,10 @@
 <form id="id_form_case_component">
-	<table class="list" cellspacing="0" cellspan="0" width="100%">
+	<table id="case-components-table" class="list" cellspacing="0" cellspan="0" width="100%">
 		<thead>
 			<tr>
-				<th  class="table_width_checkbox" align="left"><input id="id_checkbox_all_components" type="checkbox" /></th>
+				<th class="table_width_checkbox" align="left">
+					<input id="id_checkbox_all_components" type="checkbox" class="js-select-all" />
+				</th>
 				<th align="left">Name</th>
 				<th align="left">Product</th>
 				<th align="left">Actions</th>

--- a/src/templates/plan/cases_rows.html
+++ b/src/templates/plan/cases_rows.html
@@ -14,7 +14,7 @@ test_cases should be a queryset of a list of TestCases.
 	<td class="expandable js-just-loaded">
 		<img class="expand blind_icon" src="{% static "images/t1.gif" %}" border="0" alt="">
 	</td>
-	<td>
+	<td class="selector_cell">
 		{# FIXME: replacing selected_case_ids with selected_cases_ids is proper  #}
 		<input type="checkbox" name="case" value="{{ test_case.pk }}"
 		class="checkbox case_selector" {% if not selected_case_ids or test_case.pk in selected_case_ids %}checked{% endif %} />

--- a/src/templates/plan/common/plans_advance_filtered.html
+++ b/src/templates/plan/common/plans_advance_filtered.html
@@ -4,20 +4,20 @@
 		<span>
 			{% if perms.testplans.add_testplan %}
 			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url "plans-new" %}" />
-			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url "plans-clone" %}" />
+			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plans" data-param="{% url "plans-clone" %}" disabled />
 			{% endif %}
-			<input type="button" value="Printable copy" id="plan_advance_printable" disabled="disabled"
-        title="Create the printable copy for selected plans."
-        data-param="{% url "plans-printable" %}" />
-			<input type="button" value="Export" title="Export the cases for selected plans."
-        class="js-export-cases"
-        data-param="{% url "plans-export" %}" />
+			<input type="button" value="Printable copy" id="plan_advance_printable" class="js-printable-plans" disabled
+				title="Create the printable copy for selected plans." data-param="{% url "plans-printable" %}" />
+			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-plans"
+				data-param="{% url "plans-export" %}" disabled />
 		</span>
 	</div>
 	<table id="testplans_table" class="list border-bottom" cellpadding="0" cellspacing="0" border="0" style="table-layout:fixed;">
 		<thead>
 			<tr>
-				<th width="20" class="nosort"><input id="id_check_all_plans" type="checkbox" title="Select all/Select none" /></th>
+				<th width="20" class="nosort">
+					<input id="id_check_all_plans" type="checkbox" class="js-select-all" title="Select all/Select none" />
+				</th>
 				<th class="number nosort widthID" title="Sort by plan ID"><a href="{{query_url}}&order_by=plan_id">ID</a></th>
 				<th class="text nosort" title="Sort by plan name"><a href="{{query_url}}&order_by=name">Name</a></th>
 				<th width="100" class="text nosort" title="Sort by author"><a href="{{query_url}}&order_by=author__username">Author</a></th>

--- a/src/templates/plan/common/plans_filtered.html
+++ b/src/templates/plan/common/plans_filtered.html
@@ -4,18 +4,19 @@
 		<span>
 			{% if perms.testplans.add_testplan %}
 			<input type="button" title="Create new test plan" value="New Test Plan" class="js-new-plan" data-param="{% url "plans-new" %}" />
-			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plan" data-param="{% url "plans-clone" %}" />
+			<input type="button" value="Clone" title="clone selected test plans." class="js-clone-plans" data-param="{% url "plans-clone" %}" disabled />
 			{% endif %}
-			<input type="button" id="plan_list_printable"
-                   disabled="disabled" value="Printable copy"
-                   title="Create the printable copy for selected plans." data-param="{% url "plans-printable" %}" />
-			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-cases" data-param="{% url "plans-export" %}" />
+			<input type="button" id="plan_list_printable" class="js-printable-plans" disabled
+				value="Printable copy" title="Create the printable copy for selected plans."
+				data-param="{% url "plans-printable" %}" />
+			<input type="button" value="Export" title="Export the cases for selected plans." class="js-export-plans"
+				data-param="{% url "plans-export" %}" disabled />
 		</span>
 	</div>
 	<table id="testplans_table" class="list border-bottom" cellpadding="0" cellspacing="0" border="0" style="table-layout:fixed;">
 		<thead>
 			<tr>
-				<th width="20" class="nosort"><input id="id_check_all_plans" type="checkbox" title="Select all/Select none" /></th>
+				<th width="20" class="nosort"><input id="id_check_all_plans" class="js-select-all" type="checkbox" title="Select all/Select none" /></th>
 				<th class="number nosort widthID" title="Sort by plan ID">ID</th>
 				<th class="text nosort" title="Sort by plan name">Name</th>
 				<th width="100" class="text nosort" title="Sort by author">Author</th>

--- a/src/templates/plan/get_cases.html
+++ b/src/templates/plan/get_cases.html
@@ -145,7 +145,7 @@
 				</a>
 			</th>
 			<th class="nosort" align="left" width="20px">
-				<input type="checkbox" value="all" checked />
+				<input type="checkbox" class="js-select-all" value="all" checked />
 			</th>
 			<th align="left" class="widthID">
 				<a title="Sort by case ID" href="#testcases" class="js-case-field" data-param="case_id">

--- a/src/templates/plan/get_component.html
+++ b/src/templates/plan/get_component.html
@@ -8,11 +8,11 @@
 			{% endif %}
 		</div>
 	</div>
-	<table class="list" cellpadding="0" cellspacing="0">
+	<table id="components_table" class="list" cellpadding="0" cellspacing="0">
 		<thead>
 			<tr>
 				<th class="table_width_checkbox">
-					<input id="id_checkbox_all_component" type="checkbox" />
+					<input id="id_checkbox_all_component" class="js-select-all" type="checkbox" />
 				</th>
 				<th>Component</th>
 				<th>Product</th>

--- a/src/templates/plan/get_review_cases.html
+++ b/src/templates/plan/get_review_cases.html
@@ -132,7 +132,7 @@
 				</a>
 			</th>
 			<th class="nosort" align="left" width="20px">
-				<input type="checkbox" value="all" checked />
+				<input type="checkbox" class="js-select-all" value="all" checked />
 			</th>
 			<th align="left" class="widthID">
 				<a title="Sort by case ID" href="#testcases" class="js-review-case-field" data-param="case_id">

--- a/src/templates/plan/get_runs.html
+++ b/src/templates/plan/get_runs.html
@@ -68,7 +68,9 @@
 	<table class="list" id="testruns_table" cellpadding="0" cellspacing="0" border="0" data-param="{{test_plan.pk}}">
 		<thead>
 			<tr>
-				<th class="nosort" width="30"><input id="id_check_all_runs" type="checkbox" title="Select all/Select none"></th>
+				<th class="nosort" width="30">
+					<input id="id_check_all_runs" type="checkbox" class="js-select-all" title="Select all/Select none" />
+				</th>
 				<th align="left" class="nosort widthID">ID</th>
 				<th align="left" class="nosort">Test Run Summary</th>
 				<th align="left" class="nosort" width="80">Manager</th>

--- a/src/templates/plan/search_case.html
+++ b/src/templates/plan/search_case.html
@@ -83,7 +83,9 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 			<table class="list" cellpadding="0" cellspacing="0" border="0" width="100%;" id="id_table_cases" >
 				<thead>
 					<tr>
-						<th align="left" width="2%" class="nosort"><input id="id_checkbox_all_cases" type="checkbox" /></th>
+						<th align="left" width="2%" class="nosort">
+							<input id="id_checkbox_all_cases" type="checkbox" class="js-select-all" />
+						</th>
 						<th align="left" class="widthID" >ID</th>
 						<th align="left" width="20%" >Summary</th>
 						<th align="left" width="10%" >Author</th>
@@ -110,7 +112,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestPlans.SearchCase.on_load);
 				</table>
 				<div class="middle-list" >
 					<div id="searchcase" class="mixbar">
-						<input type="submit" value="Add selected cases" />
+						<input id="add-selected-cases" type="submit" value="Add selected cases" disabled />
 					</div>
 				</div>
 				{% else %}

--- a/src/templates/profile/bookmarks.html
+++ b/src/templates/profile/bookmarks.html
@@ -40,7 +40,9 @@ Nitrate.Utils.after_page_load(Nitrate.Profiles.Bookmarks.on_load);
 			<table id="id_table_bookmark" cellpadding="0" cellspacing="0" class="table_watchlist" >
 				<thead>
 					<tr>
-						<th width="30px" class="nosort"><div class="leftradius"></div><input id="id_check_all_bookmark" 	type="checkbox" /></th>
+						<th width="30px" class="nosort">
+							<input id="id_check_all_bookmark" class="js-select-all" type="checkbox" />
+						</th>
 						<th width="40px">Index</th>
 						<th>Name</th>
 						<th><div class="rightradius"></div>Description</th>

--- a/src/templates/run/common/run_advance_filtered.html
+++ b/src/templates/run/common/run_advance_filtered.html
@@ -1,12 +1,14 @@
 <form id='runs_form'>
 	<div id="contentTab" class="mixbar">
 		<span class="tit"><a href="{% url "runs-all" %}?case_run__assignee={{ user.email }}">View My Assigned Runs</a></span>
-		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" data-param="{% url "runs-clone" %}" />
+		<input type="button" value="Clone" title="clone selected test runs" class="js-clone-testruns" disabled data-param="{% url "runs-clone" %}" />
 	</div>
 	<table id="testruns_table" class="list border-bottom js-advance-search-runs" cellpadding="0" cellspacing="0" border="0">
 		<thead>
 			<tr >
-				<th width="30"><input id='id_check_all_runs' type="checkbox" title="Select all/Select none" /></th>
+				<th width="30">
+					<input id='id_check_all_runs' class="js-select-all" type="checkbox" title="Select all/Select none" />
+				</th>
 				<th class="widthID"><a href="{{query_url}}&order_by=run_id" title="Sort by Run ID">ID</a></th>
 				<th><a href="{{query_url}}&order_by=summary" title="Sort by Summary">Summary</a></th>
 				<th width="80"><a href="{{query_url}}&order_by=manager__username" title="Sort by Manager Name">Manager</a></th>

--- a/src/templates/run/common/run_filtered.html
+++ b/src/templates/run/common/run_filtered.html
@@ -1,7 +1,9 @@
 <table id="testruns_table" class="list border-bottom" cellpadding="0" cellspacing="0" border="0">
 	<thead>
 		<tr >
-			<th class="nosort" width="30"><input id='id_check_all_runs' type="checkbox" title="Select all/Select none" /></th>
+			<th class="nosort" width="30">
+				<input id="id_check_all_runs" class="js-select-all" type="checkbox" title="Select all/Select none" />
+			</th>
 			<th class="number nosort widthID">ID</th>
 			<th class="text nosort">Summary</th>
 			<th class="text nosort" width="80">Manager</th>

--- a/src/templates/run/table_caseruns.html
+++ b/src/templates/run/table_caseruns.html
@@ -3,7 +3,7 @@
 	<thead>
 		<tr>
 			<th width="20">
-				<input id="id_check_all_button" type="checkbox" title="Select all cases/Select none case" />
+				<input id="id_check_all_button" type="checkbox" class="js-select-all" title="Select all cases/Select none case" />
 			</th>
 			<th width="18">
 				<a id="id_blind_all_link" title="Expand all cases">
@@ -27,8 +27,8 @@
 	<tbody>
 		{% for test_case_run, tester, assignee, priority_value, status_name, comments_count, issues_count in test_case_runs %}
 		<tr class="{% cycle 'odd' 'even' %} {% ifequal test_case_run.assignee_id user.pk %} mine {% endifequal %}">
-			<td>
-				<input type="checkbox" name="case_run" value="{{ test_case_run.pk }}" class="caserun_selector" title="Select/Unselect" />
+			<td class="selector_cell">
+				<input type="checkbox" name="case_run" value="{{ test_case_run.pk }}" title="Select/Unselect" />
 				<input type="hidden" name="case" value="{{ test_case_run.case.pk }}" />
 				<input type="hidden" name="case_text_version" value="{{ test_case_run.case_text_version }}" />
 			</td>

--- a/src/templates/search/runs.html
+++ b/src/templates/search/runs.html
@@ -2,6 +2,6 @@
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/management_actions.js" %}"></script>
 <script type="text/javascript">
-	Nitrate.Utils.after_page_load(Nitrate.TestRuns.List.on_load);
+	Nitrate.Utils.after_page_load(Nitrate.TestRuns.AdvancedSearch.on_load);
 </script>
 {% include "run/common/run_advance_filtered.html" %}


### PR DESCRIPTION
Upgrade this plugin to the latest version in upstream and enable it for
tables.

Meanwhile, some relative code are refactored to simplify the implement
the select all and enable/disable related buttons according the checked
status.

Fixes #660

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>