### PR TITLE
Use gettext_lazy

### DIFF
--- a/src/tcms/auth/apps.py
+++ b/src/tcms/auth/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig as DjangoAppConfig
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def user_klass_clean(self):

--- a/src/tcms/auth/forms.py
+++ b/src/tcms/auth/forms.py
@@ -3,7 +3,7 @@
 from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import UserActivateKey
 

--- a/src/tcms/comments/apps.py
+++ b/src/tcms/comments/apps.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.apps import AppConfig as DjangoAppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AppConfig(DjangoAppConfig):

--- a/src/tcms/comments/forms.py
+++ b/src/tcms/comments/forms.py
@@ -3,7 +3,7 @@
 from django import forms
 from django_comments.forms import CommentDetailsForm
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 COMMENT_MAX_LENGTH = getattr(settings, 'COMMENT_MAX_LENGTH', 10000)
 

--- a/src/tcms/core/apps.py
+++ b/src/tcms/core/apps.py
@@ -6,7 +6,7 @@ from django.apps import AppConfig as DjangoAppConfig
 from django.conf import settings
 from django.db import connections
 from django.db.models.signals import post_migrate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 

--- a/src/tcms/core/forms/fields.py
+++ b/src/tcms/core/forms/fields.py
@@ -6,7 +6,7 @@ from django import forms
 from django.db.models import Q
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from tcms.core.utils import string_to_list, timedelta2int
 

--- a/src/tcms/profiles/forms.py
+++ b/src/tcms/profiles/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ObjectDoesNotExist
 from django import forms
 from django.contrib.auth.models import User

--- a/src/tcms/search/views.py
+++ b/src/tcms/search/views.py
@@ -5,6 +5,7 @@ Advance search implementations
 """
 
 import time
+from typing import List
 
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
@@ -143,16 +144,16 @@ def render_results(request, results, start_time, queries,
     paginator = Paginator(results, 20)
     page = request.GET.get('page')
     try:
-        # Evaluate queryset in order to calculate query time cost later.
-        this_page = list(paginator.page(page))
+        this_page = paginator.page(page)
     except PageNotAnInteger:
         this_page = paginator.page(1)
 
     page_start = paginator.per_page * (this_page.number - 1) + 1
-    page_end = page_start + min(len(this_page.object_list),
-                                paginator.per_page) - 1
+    page_end = (
+        page_start + min(len(this_page.object_list), paginator.per_page) - 1
+    )
 
-    calculate_associated_data(this_page, queries['Target'])
+    calculate_associated_data(list(this_page), queries['Target'])
 
     end_time = time.time()
     time_cost = round(end_time - start_time, 3)
@@ -234,7 +235,7 @@ def fmt_queries(*queries):
     return results
 
 
-def calculate_associated_data(queryset, query_target):
+def calculate_associated_data(queryset: List, query_target):
     """Calculate associated data and attach to objects in queryset"""
 
     # FIXME: Maybe plan and case associated data could be calculated here as well.

--- a/src/tcms/xmlrpc/apps.py
+++ b/src/tcms/xmlrpc/apps.py
@@ -3,7 +3,7 @@
 import os
 
 from django.apps import AppConfig as DjangoAppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from tcms.xmlrpc.filters import autowrap_xmlrpc_apis
 


### PR DESCRIPTION
Suppress warning:

RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is
deprecated in favor of django.utils.translation.gettext_lazy().

Fixes #637

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>