### PR TITLE
Fix to make Nitrate run well in release container

### DIFF
--- a/contrib/conf/nitrate-httpd.conf
+++ b/contrib/conf/nitrate-httpd.conf
@@ -19,9 +19,11 @@ MaxSpareServers 10
 MaxClients 256
 MaxRequestsPerChild 0
 
-<IfFile conf.d/wsgi-venv.conf>
-    Include conf.d/wsgi-venv.conf
-</IfFile>
+WSGIDaemonProcess nitrateapp processes=2
+WSGIProcessGroup nitrateapp
+WSGIApplicationGroup %{GLOBAL}
+WSGIScriptAlias / /usr/lib/python3.7/site-packages/tcms/wsgi.py
+WSGIPassAuthorization On
 
 <Location "/">
     # ====================

--- a/contrib/conf/wsgi-venv.conf
+++ b/contrib/conf/wsgi-venv.conf
@@ -1,7 +1,0 @@
-# Run Nitrate from a Python virtual environment.
-# Refer to https://modwsgi.readthedocs.io/en/develop/user-guides/virtual-environments.html
-WSGIDaemonProcess nitrateapp python-home=/prodenv
-WSGIProcessGroup nitrateapp
-WSGIApplicationGroup %{GLOBAL}
-WSGIScriptAlias / /prodenv/lib64/python3.7/site-packages/tcms/wsgi.py
-WSGIPassAuthorization On

--- a/docker/released/Dockerfile
+++ b/docker/released/Dockerfile
@@ -23,19 +23,15 @@ RUN dnf update -y && \
       --setopt=deltarpm=0 \
       --setopt=install_weak_deps=false \
       --setopt=tsflags=nodocs \
-      httpd python3-nitrate-tcms \
+      httpd \
+      python3-mod_wsgi \
+      python3-nitrate-tcms && \
     dnf clean all
 
 # Hack: easier to set database password via environment variable
-COPY ./docker/released/product.py src/tcms/settings/product.py
+COPY ./docker/released/product.py /usr/lib/python3.7/site-packages/tcms/settings/product.py
 
 COPY ./contrib/conf/nitrate-httpd.conf /etc/httpd/conf.d/
-
-# Just copying without renaming will cause error :
-# AH00526: Syntax error on line 3 of /etc/httpd/conf.d/wsgi-venv.conf:
-# Name duplicates previous WSGI daemon definition.
-# However, if rename it with prefix "00-", it works well.
-COPY ./contrib/conf/wsgi-venv.conf /etc/httpd/conf.d/00-wsgi-venv.conf
 
 # Disable event module and enable prefork module
 RUN sed -i -e 's/^#\(LoadModule mpm_prefork_module .\+\.so\)$/\1/' \

--- a/python-nitrate-tcms.spec
+++ b/python-nitrate-tcms.spec
@@ -35,7 +35,7 @@ BuildRequires:  python3dist(django-uuslug)
 BuildRequires:  python3dist(html2text)
 BuildRequires:  python3dist(kerberos)
 BuildRequires:  python3dist(odfpy)
-BuildRequires:  python3dist(pymysql)
+BuildRequires:  python3dist(mysqlclient)
 BuildRequires:  python3dist(python-bugzilla)
 BuildRequires:  python3dist(xmltodict)
 
@@ -48,8 +48,6 @@ BuildRequires:  python3dist(sphinx-rtd-theme)
 # Required by the Django SQL backend during tests run
 BuildRequires:  python3dist(sqlparse)
 
-Requires:       mod_auth_gssapi
-Requires:       mod_wsgi
 Requires:       python3-kobo-django
 Requires:       python3dist(beautifulsoup4)
 Requires:       python3dist(celery)
@@ -60,7 +58,7 @@ Requires:       python3dist(django-uuslug)
 Requires:       python3dist(html2text)
 Requires:       python3dist(kerberos)
 Requires:       python3dist(odfpy)
-Requires:       python3dist(pymysql)
+Requires:       python3dist(mysqlclient)
 Requires:       python3dist(python-bugzilla)
 Requires:       python3dist(xmltodict)
 

--- a/src/tcms/wsgi.py
+++ b/src/tcms/wsgi.py
@@ -24,11 +24,6 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tcms.settings.product")
 os.environ['PYTHON_EGG_CACHE'] = '/tmp/.python-eggs/'
 
-# add tcms's core lib path
-import tcms, sys
-# tcms should exist in only one path.
-sys.path.append(os.path.join(tcms.__path__[0], 'core', 'lib'))
-
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
@@ -42,7 +37,3 @@ def application(environ, start_response):
         environ['HTTPS'] = 'on'
     
     return _application(environ, start_response)
-
-# Apply WSGI middleware here.
-# from helloworld.wsgi import HelloWorldApplication
-# application = HelloWorldApplication(application)


### PR DESCRIPTION
* Remove unnecessary code and commented out lines from wsgi.py
* Since Nitrate has been Python 3 only already, remove mod_wsgi from
  SPEC file. mod_auth_gssapi is removed as well. The deployment
  artifacts, e.g. the Dockerfile, should be the right place to install
  required packages.
* Use mysqlclient rather than pymysql in SPEC which was replaced in the
  Python distribution already.
* Install missing python3-mod_wsgi in Dockerfile
* It is also fixed to copy product.py to right settings directory in
  Dockerfile.
* Delete wsgi-venv.conf and merge its content into nitrate-httpd.conf
  directly. python-home is removed since Nitrate is not installed into a
  virtual environment in the container, and the path of wsgi.py is also
  fixed accordingly.
* Remove COPY of wsgi-venv.conf from Dockerfile.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>