### PR TITLE
JS: simplify the event handlers in plan cases details pane

### DIFF
--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -944,7 +944,6 @@ function renderComponentForm(container, parameters, formObserve) {
   });
 }
 
-
 /************ Dialog operations *****************/
 
 function getDialog(element) {

--- a/src/templates/plan/get_cases.html
+++ b/src/templates/plan/get_cases.html
@@ -5,8 +5,6 @@
 	<input type="hidden" name="plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
 	<input type="hidden" name="from_plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
 	<input type="hidden" name="template_type" value="{{ REQUEST_CONTENTS.template_type }}" />
-	<input type="hidden" name="new_case_status_id" />
-	<input type="hidden" name="new_priority_id" />
 	<div class="tab_navigation actions">
 		<div class='toolbar'>
 			<ul>

--- a/src/templates/plan/get_review_cases.html
+++ b/src/templates/plan/get_review_cases.html
@@ -6,8 +6,6 @@
 	<input type="hidden" name="plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
 	<input type="hidden" name="from_plan" value="{{ REQUEST_CONTENTS.from_plan }}" />
 	<input type="hidden" name="template_type" value="{{ REQUEST_CONTENTS.template_type }}" />
-	<input type="hidden" name="new_case_status_id" />
-	<input type="hidden" name="new_priority_id" />
 	<div class="tab_navigation actions">
 		<div class='toolbar'>
 			<ul>


### PR DESCRIPTION
This patch simplifies the event handler calls in plan's cases details
pane by moving the handler code into constructPlanDetailsCasesZone
directly. It looks the function is too big, however it reduces the
function calls by passing arguments through several levels. In practice,
it will be much easier to understand the event handlers.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>