### PR TITLE
Set email_settings to new plan (#737)

### DIFF
--- a/src/tcms/testplans/models.py
+++ b/src/tcms/testplans/models.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Max
 from django.db.models.signals import post_save, post_delete, pre_delete, pre_save
+from django.dispatch import receiver
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from uuslug import slugify
@@ -512,6 +513,12 @@ class TCMSEnvPlanMap(models.Model):
 
     class Meta:
         db_table = 'tcms_env_plan_map'
+
+
+@receiver(post_save, sender=TestPlan)
+def set_email_settings_to_new_plan(sender, **kwargs):
+    if kwargs['created']:
+        TestPlanEmailSettings.objects.create(plan=kwargs['instance'])
 
 
 if register_model:

--- a/src/tcms/testplans/views.py
+++ b/src/tcms/testplans/views.py
@@ -50,7 +50,6 @@ from tcms.testplans.forms import PlanComponentForm
 from tcms.testplans.forms import SearchPlanForm
 from tcms.testplans import sqls
 from tcms.testplans.models import TestPlan, TestPlanComponent
-from tcms.testplans.models import TestPlanEmailSettings
 from tcms.testruns.models import TestRun, TestCaseRun
 
 
@@ -128,8 +127,6 @@ class CreateNewPlanView(PermissionRequiredMixin, View):
             extra_link=form.cleaned_data['extra_link'],
             parent=form.cleaned_data['parent'],
         )
-
-        TestPlanEmailSettings.objects.create(plan=tp)
 
         tp.add_text(author=request.user, plan_text=form.cleaned_data['text'])
 

--- a/src/tests/testplans/test_models.py
+++ b/src/tests/testplans/test_models.py
@@ -17,11 +17,11 @@ class TestSendEmailOnPlanUpdated(test.TestCase):
     def setUpTestData(cls):
         cls.owner = f.UserFactory(username='owner', email='owner@example.com')
         cls.plan = f.TestPlanFactory(owner=cls.owner, author=cls.owner)
-        f.TestPlanEmailSettingsFactory(
-            auto_to_plan_owner=True,
-            auto_to_plan_author=True,
-            notify_on_plan_update=True,
-            plan=cls.plan)
+
+        cls.plan.email_settings.auto_to_plan_owner = True
+        cls.plan.email_settings.auto_to_plan_author = True
+        cls.plan.email_settings.notify_on_plan_update = True
+        cls.plan.email_settings.save()
 
     def setUp(self):
         _listen()
@@ -48,11 +48,11 @@ class TestSendEmailOnPlanDeleted(test.TestCase):
     def setUpTestData(cls):
         cls.owner = f.UserFactory(username='owner', email='owner@example.com')
         cls.plan = f.TestPlanFactory(owner=cls.owner, author=cls.owner)
-        f.TestPlanEmailSettingsFactory(
-            auto_to_plan_owner=True,
-            auto_to_plan_author=True,
-            notify_on_plan_delete=True,
-            plan=cls.plan)
+
+        cls.plan.email_settings.auto_to_plan_owner = True
+        cls.plan.email_settings.auto_to_plan_author = True
+        cls.plan.email_settings.notify_on_plan_delete = True
+        cls.plan.email_settings.save()
 
     def setUp(self):
         _listen()
@@ -95,8 +95,6 @@ class TestGetPlanNotificationRecipients(test.TestCase):
             author=f.UserFactory(username='user6'),
             default_tester=f.UserFactory(username='user7', email=''),
             plan=[cls.plan])
-
-        f.TestPlanEmailSettingsFactory(plan=cls.plan)
 
     def test_collect_recipients(self):
         # Test data is a tuple of 5-elements tuples, each of one contains:

--- a/src/tests/testplans/test_views.py
+++ b/src/tests/testplans/test_views.py
@@ -57,7 +57,6 @@ class PlanTests(HelperAssertions, test.TestCase):
             author=cls.user,
             product=cls.product,
             type=cls.plan_type)
-        cls.email_settings = f.TestPlanEmailSettingsFactory(plan=cls.test_plan)
         cls.plan_id = cls.test_plan.pk
 
     def test_open_plans_search(self):
@@ -492,6 +491,8 @@ class TestCloneView(BasePlanCase):
                            link_cases=True, copy_cases=None,
                            maintain_case_orignal_author=None,
                            keep_case_default_tester=None):
+        self.assertIsNotNone(cloned_plan.email_settings)
+
         self.assertEqual(f'Copy of {original_plan.name}', cloned_plan.name)
         self.assertEqual(Product.objects.get(pk=self.product.pk), cloned_plan.product)
         self.assertEqual(Version.objects.get(pk=self.version.pk), cloned_plan.product_version)


### PR DESCRIPTION
The new plan could be created by creating a new plan or cloning an
existing plan.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>