### PR TITLE
Fix GroupByResult.__getitem__ (#772)

### DIFF
--- a/src/tcms/core/db.py
+++ b/src/tcms/core/db.py
@@ -135,7 +135,9 @@ class GroupByResult:
         # Behave like what collections.defaultdict does. If a key does not exist
         # yet, just return 0. This is based on the assumption of the value type
         # within GroupByResult could be integer or a nested GroupByResult.
-        return self._data.__getitem__(key) if key in self._data else 0
+        if key in self._data:
+            return self._data.__getitem__(key)
+        raise KeyError(f'Unknown key {key} inside the group by result.')
 
     def __setitem__(self, key, value):
         r = self._data.__setitem__(key, value)

--- a/src/tcms/report/data.py
+++ b/src/tcms/report/data.py
@@ -342,8 +342,10 @@ class CustomDetailsReportData(CustomReportData):
 
             status_name = case_run_status_names[case_run_status_id]
             run_node[status_name] = status_count
+
             # calculate the last total line
-            status_total_line[status_name] += status_count
+            status_total_line[status_name] = \
+                status_total_line.setdefault(status_name, 0) + status_count
 
         # Add total line to final data set
         matrix_dataset[None] = status_total_line

--- a/src/tests/core/test_core.py
+++ b/src/tests/core/test_core.py
@@ -113,6 +113,10 @@ class GroupByResultDictLikeTest(unittest.TestCase):
         self.assertNotIn('count', self.groupby_result)
         self.assertEqual(len(self.groupby_result), 0)
 
+    def test_raise_key_error(self):
+        with self.assertRaises(KeyError):
+            self.groupby_result['unknown_key']
+
 
 class GroupByResultCalculationTest(unittest.TestCase):
     """Test calculation of GroupByResult"""
@@ -188,11 +192,6 @@ class GroupByResultCalculationTest(unittest.TestCase):
     def test_zero_percentage(self):
         result = GroupByResult({})
         self.assertEqual(.0, result.PASSED_percent)
-
-    def test_default_zero(self):
-        result = GroupByResult()
-        result['RUNNING'] += 1
-        self.assertEqual(1, result['RUNNING'])
 
 
 class GroupByResultLevelTest(unittest.TestCase):


### PR DESCRIPTION
Raise KeyError if key does not exist in the _data. This is for making
GroupByResult to be a real dict-like object.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>