### PR TITLE
Encode author email in My Plans querystring (#262)

### DIFF
--- a/src/templates/menu.html
+++ b/src/templates/menu.html
@@ -13,7 +13,7 @@
 				</li>
 				{% if user.is_authenticated %}
 				<li {% if sub_module == 'my_plans' %} class="subcurrent"{% endif %} >
-					<a href="{% url "plans-all" %}?author__email__startswith={{ user.email }}&is_active=on">My Plans</a>
+					<a href="{% url "plans-all" %}?author__email__startswith={{ user.email|urlencode }}&is_active=on">My Plans</a>
 				</li>
 				{% endif %}
 				{% if perms.testplans.add_testplan %}


### PR DESCRIPTION
For example a user has email a+b@example.com, without this encode,
'a+b@example.com' will be present in the URL querystring, and then the
email address will be in the textbox as 'a b@example.com' eventually.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>