### PR TITLE
Remove six module from files.py

### DIFF
--- a/src/tcms/core/files.py
+++ b/src/tcms/core/files.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import urllib.parse
 
 from datetime import datetime
 from http import HTTPStatus
@@ -17,7 +18,6 @@ from django.utils.encoding import smart_str
 from django.views import generic
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_GET, require_POST
-from six.moves.urllib_parse import unquote
 
 from tcms.core.views import prompt
 from tcms.testcases.models import TestCase, TestCaseAttachment
@@ -125,7 +125,7 @@ def check_file(request, file_id):
         # system.
         stored_file_name = os.path.join(
             settings.FILE_UPLOAD_DIR,
-            unquote(attachment.stored_name or attachment.file_name)
+            urllib.parse.unquote(attachment.stored_name or attachment.file_name)
         ).replace('\\', '/')
 
         if not os.path.exists(stored_file_name):


### PR DESCRIPTION
It's strange, six is still imported in this file. Is it not covered by
tests, or the test environment is not provisioned properly inside which
six is installed accidentially? Not sure. Anyway, remove it and replaced
with Python 3 urllib.parse.unquote.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>