### PR TITLE
JS: reload case run detail pane only once

### DIFF
--- a/src/static/js/comment.js
+++ b/src/static/js/comment.js
@@ -29,12 +29,12 @@ function submitComment(container, parameters, callback) {
 /**
  * Update comments count by increasing or decreasing the number.
  *
- * @param {string} caseId - the case id used to select specific elements to be updated.
+ * @param {number} caseId - the case id used to select specific elements to be updated.
  * @param {boolean} increase - increase or decrease the number.
  */
 function updateCommentsCount(caseId, increase) {
-  let commentDiv = jQ('#' + caseId + '_case_comment_count');
-  let countText = jQ('#' + caseId + '_comments_count');
+  let commentDiv = jQ('#' + caseId.toString() + '_case_comment_count');
+  let countText = jQ('#' + caseId.toString() + '_comments_count');
   if (increase) {
     if (commentDiv.children().length === 1) {
       commentDiv.prepend('<img src="/static/images/comment.png" style="vertical-align: middle;">');
@@ -42,7 +42,7 @@ function updateCommentsCount(caseId, increase) {
     countText.text(' ' + (parseInt(countText.text()) + 1));
   } else {
     if (parseInt(countText.text(), 10) === 1) {
-      commentDiv.html('<span id="' + caseId + '_comments_count"> 0</span>');
+      commentDiv.html('<span id="' + caseId.toString() + '_comments_count"> 0</span>');
     } else {
       countText.text(' ' + (parseInt(commentDiv.text()) - 1));
     }

--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -14,6 +14,8 @@ const SHORT_STRING_LENGTH = 100;
  * @param {Function} callback - a callback function that will be called at
  *                              window.load event.
  */
+// FIXME: the callback should not be registered to window.on_load event directly.
+// By doing that, the callback's this is modified that brings extra effort to handle the this object.
 Nitrate.Utils.after_page_load = function (callback) {
   jQ(window).on('load', callback);
 };

--- a/src/templates/case/get_details_case_run.html
+++ b/src/templates/case/get_details_case_run.html
@@ -83,7 +83,7 @@
 						[ <a href="{% url "run-caserun-file-issue" run_id=test_case_run.run.pk case_run_id=test_case_run.pk %}" target="_blank" class="buglink" title="File a bug on bugzilla">File</a>&nbsp;|&nbsp;
 						{% if perms.issuetracker.add_issue %}
 						<a href="javascript:void(0);" title="Add an issue" class="js-add-caserun-issue"
-							data-params='{"runId": {{ test_case_run.run_id }}, "caseId": {{ test_case_run.case_id }}, "caseRunIds": [{{ test_case_run.pk }}]}'>Add</a>
+							data-params='{"runId": {{ test_case_run.run_id }}, "caseRunIds": [{{ test_case_run.pk }}]}'>Add</a>
 						{% endif %} ]
 					</span>
 				</h4>
@@ -218,7 +218,7 @@
 				<table cellpadding="0" cellspacing="0" border="0" width="98%;" style="margin:0 auto;">
 					<tr>
 						<td>
-							<h4 class="borderB">Test Log <span>[<a href="javascript:void(0);" class="js-add-testlog" data-params='[{{ test_case_run.case_id }}, {{ test_case_run.pk }}]'>Add</a>]</span></h4>
+							<h4 class="borderB">Test Log <span>[<a href="javascript:void(0);" class="js-add-testlog">Add</a>]</span></h4>
 							<div class="content">
 									<ul class="ul-format">
 										{% for link in test_case_run.links.all %}

--- a/src/templates/run/get_case_runs.html
+++ b/src/templates/run/get_case_runs.html
@@ -43,8 +43,8 @@
 		<div class="btnBlueCaserun">
 			<span>Issues</span>
 			<ul>
-				<li><a href="javascript:void(0);" class="addBlue9 js-add-issues" data-add-issue-info='{"runId": {{ test_run.pk }}}' data-reload-info='{"reloadPage": true}'>Add</a></li>
-				<li><a href="javascript:void(0);" class="removeBlue9 js-remove-issues" data-remove-issue-info='{"runId": {{ test_run.pk }}}' data-reload-info='{"reloadPage": true}'>Remove</a></li>
+				<li><a href="javascript:void(0);" class="addBlue9 js-add-issues" data-add-issue-info='{"runId": {{ test_run.pk }}}'>Add</a></li>
+				<li><a href="javascript:void(0);" class="removeBlue9 js-remove-issues" data-remove-issue-info='{"runId": {{ test_run.pk }}}'>Remove</a></li>
 			</ul>
 		</div>
 		<div class="btnBlueCaserun">

--- a/src/tests/testcases/test_views.py
+++ b/src/tests/testcases/test_views.py
@@ -2468,11 +2468,10 @@ class TestCaseCaseRunDetailPanelView(BaseCaseRun):
             '<ul class="ul-no-format"><li class="grey">No component found</li></ul>',
             '<ul class="ul-no-format"><li class="grey">No tag found</li></ul>',
 
-            f'<h4 class="borderB">Test Log <span>'
-            f'[<a href="javascript:void(0);" class="js-add-testlog" '
-            f'data-params="[{case_run.case_id}, {case_run.pk}]">Add</a>]'
-            f'</span></h4>'
-            f'<div class="content"><ul class="ul-format"></ul></div>',
+            '<h4 class="borderB">Test Log <span>'
+            '[<a href="javascript:void(0);" class="js-add-testlog">Add</a>]'
+            '</span></h4>'
+            '<div class="content"><ul class="ul-format"></ul></div>',
 
             '<h4>Actions</h4><div class="content"></div>',
             '<h4>Breakdown</h4><div class="content"></div>',


### PR DESCRIPTION
The original problem is a regression bug that is when a case run related
data is changed, for example adding a comment, the code will find all
elements which have class .expandable and trigger the click to load
those details. In addition, the original behavior before this regression
the case run detail endpoint was requested twice in order to reload the
detail.

This patch refactors the relative codebase a lot to reload the
detail only once. The relative behaviors are:

* change case run status
* add a comment to a case run
* remove a comment to a case run
* add an issue to a case run
* remove an issue from a case run
* add a link to a case run

This patch also fixes a bug that is to update the number of issues to
the case run row.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>