### PR TITLE
Fix case run status button CSS style for disabled

### DIFF
--- a/src/static/style/base.css
+++ b/src/static/style/base.css
@@ -917,21 +917,21 @@ ul.data_content_title li{ display:inline-block; margin-left:3px;}
 .icon_status {display:inline-block; padding-left:23px; height:23px; line-height:23px; background:url(../images/ico_status.png) no-repeat;}
 .btn_status {display:inline-block; width:23px; height:23px; line-height:23px; background:url(../images/ico_status.png) no-repeat; margin-right:4px; border:0px; float:left; cursor:pointer;}
 .btn_passed{background-position:0px -207px;}
-.btn_passed[disabled="True"]{background-position:0px -253px;}
+.btn_passed[disabled]{background-position:0px -253px;}
 .btn_failed{background-position:0px -345px;}
-.btn_failed[disabled="True"]{background-position:0px -391px;}
+.btn_failed[disabled]{background-position:0px -391px;}
 .btn_blocked{background-position:0px -483px;}
-.btn_blocked[disabled="True"]{background-position:0px -529px;}
+.btn_blocked[disabled]{background-position:0px -529px;}
 .btn_idle{background-position:0px -276px;}
-.btn_idle[disabled="True"]{background-position:0px -322px;}
+.btn_idle[disabled]{background-position:0px -322px;}
 .btn_paused{background-position:0px -138px;}
-.btn_paused[disabled="True"]{background-position:0px -184px;}
+.btn_paused[disabled]{background-position:0px -184px;}
 .btn_error{background-position:0px -414px;}
-.btn_error[disabled="True"]{background-position:0px -460px;}
+.btn_error[disabled]{background-position:0px -460px;}
 .btn_running{background-position:0px -69px;}
-.btn_running[disabled="True"]{background-position:0px -115px;}
+.btn_running[disabled]{background-position:0px -115px;}
 .btn_waived{background-position:0px 0px;}
-.btn_waived[disabled="True"]{background-position:0px -46px;}
+.btn_waived[disabled]{background-position:0px -46px;}
 
 /* plan icon */
 .icon_plan{background-image:url(../images/ico_plan.png); background-repeat:no-repeat; background-color:transparent; display:block; border:0px; cursor:pointer; font-size:12px; margin-right:5px; padding-left:16px; line-height:18px; }


### PR DESCRIPTION
This is a regression just found. Every case run's status button should
be in gray color to reflect the disabled status.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>