### PR TITLE
JS: fix error when save an environment group

### DIFF
--- a/src/static/js/management_actions.js
+++ b/src/static/js/management_actions.js
@@ -13,10 +13,9 @@ Nitrate.Management.Environment.Edit = {
 
     jQ('#js-edit-group').submit(function (e) {
       e.preventDefault();
-      let form = jQ(this);
       postHTMLRequest({
-        url: form.prop('action'),
-        data: form.serialize(),
+        url: this.getAttribute('action'),
+        data: jQ(this).serialize(),
         success: function () {
           window.location = '/environment/groups/';
         },


### PR DESCRIPTION
The request URL is got from form action incorrectly. That causes the
global CSRF token cannot be read and set into the request header.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>