### PR TITLE
Fix report overall

### DIFF
--- a/src/tcms/report/data.py
+++ b/src/tcms/report/data.py
@@ -93,7 +93,7 @@ def subtotal_case_run_status(filter_=None, by=None):
     })
 
 
-def subtotal_plans(filter_=None, by=None):
+def subtotal_plans(filter_=None, by=None) -> GroupByResult:
     group_by = by or 'product'
     stats = TestPlan.objects
     if filter_:

--- a/src/tcms/report/views.py
+++ b/src/tcms/report/views.py
@@ -42,10 +42,8 @@ MODULE_NAME = "report"
 REPORT_VIEW_CACHE_DURATION = 0  # 60 * 10
 
 
-def overall(request, template_name='report/list.html'):
+def overall(request):
     """Overall of products report"""
-    SUB_MODULE_NAME = 'overall'
-
     products = {
         item['pk']: item['name'] for item in
         Product.objects.values('pk', 'name')
@@ -59,17 +57,17 @@ def overall(request, template_name='report/list.html'):
             yield (
                 product_id,
                 product_name,
-                plans_count[product_id],
-                runs_count[product_id],
-                cases_count[product_id],
+                plans_count.get(product_id, 0),
+                runs_count.get(product_id, 0),
+                cases_count.get(product_id, 0),
             )
 
     context_data = {
         'module': MODULE_NAME,
-        'sub_module': SUB_MODULE_NAME,
+        'sub_module': 'overall',
         'products': generate_product_stats(),
     }
-    return render(request, template_name, context=context_data)
+    return render(request, 'report/list.html', context=context_data)
 
 
 @cache_page(REPORT_VIEW_CACHE_DURATION)

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -103,10 +103,9 @@ class TestAdvancedSearch(BaseCaseRun):
         self.client.get(self.url)
 
     def test_basic_search_plans(self):
-        # Note that, asc is not passed, which means to sort by desc order.
+        # Note that, asc is not passed, which means to sort by pk in desc order.
         resp = self.client.get(self.url, {
             'pl_product': self.product.pk,
-            'order_by': 'name',
             'target': 'plan',
         })
 
@@ -124,9 +123,7 @@ class TestAdvancedSearch(BaseCaseRun):
             # The 3rd td contains name
             plan_names.append(tr.find_all('td')[2].a.text.strip())
 
-        self.assertListEqual(
-            sorted([self.plan_02.name, self.plan.name], reverse=True),
-            plan_names)
+        self.assertListEqual([self.plan_02.name, self.plan.name], plan_names)
 
     def test_basic_search_cases(self):
         resp = self.client.get(self.url, {


### PR DESCRIPTION
If a product has not either plan, case or run, get the default value 0
from statistics correctly to generate the report.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>