### PR TITLE
JS: allow to change case run status without comment

### DIFF
--- a/src/static/js/testrun_actions.js
+++ b/src/static/js/testrun_actions.js
@@ -496,6 +496,7 @@ Nitrate.TestRuns.Details.registerEventHandlersForCaseRunDetail = function (loadD
     });
 
   caseRunDetailRow.find('.js-status-button').on('click', function () {
+    this.form.comment.required = false;
     this.form.value.value = jQ(this).data('formvalue');
   });
 


### PR DESCRIPTION
This is actually a regression bug. Restore the original behavior.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>