### PR TITLE
JS: refactor detail expansion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,8 +61,6 @@ module.exports = {
     'showModal': 'readonly',
     'SHORT_STRING_LENGTH': 'readonly',
     'splitString': 'readonly',
-    'toggleExpandArrow': 'readonly',
-    'toggleTestCasePane': 'readonly',
     'updateObject': 'readonly',
   },
   'parserOptions': {

--- a/src/static/js/nitrate.toggledetail.js
+++ b/src/static/js/nitrate.toggledetail.js
@@ -1,0 +1,202 @@
+/* global RIGHT_ARROW, DOWN_ARROW */
+
+/**
+ * @file Operation on the entity's detail expansion or collapse. This is for test case and the test
+ *       case run particularly.
+ * @author Chenxiong Qi
+ */
+
+/**
+ * Base class for entity detail expansion and collapse. The entity is the case or case run particularly.
+ *
+ * @param {HTMLElement} originalElement
+ *  the original element from which to trigger the expansion or collapse operation. This is usually
+ *  an element having a CSS class .expandable inside a case TR row.
+ * @class
+ */
+function DetailExpansion(originalElement) {
+  this.originalElement = originalElement;
+  this.entityRow = jQ(this.originalElement).parents('tr:first');
+  this.detailRow = this.entityRow.next();
+  this.caseId = window.parseInt(this.entityRow.find('input[name="case"]')[0].value);
+  this.isDetailLoaded = this.detailRow.find('.ajax_loading').length === 0;
+  this.colspan = this.entityRow.find('td').length;
+  this.imgExpansionIcon = this.entityRow.find('img.blind_icon');
+  if (this.imgExpansionIcon === undefined) {
+    throw new Error('No expansion icon image is found in the case row.');
+  }
+}
+
+/**
+ * Load the entity detail. This method should be overriden in the subclass to load the specific
+ * specific entity's detail, e.g. case or case run in particular.
+ *
+ * @param {Function} [callback]
+ *  a function registered to a proper HTTP request function to be called after the detail content is
+ *  filled into the container.
+ */
+DetailExpansion.prototype.expand = function (callback) {
+  throw new Error('This method should be called on subclass.');
+};
+
+/**
+ * Toggle the entity's detail content.
+ *
+ * @param {Function} [callback] - passed to instance function expand.
+ */
+DetailExpansion.prototype.toggle = function (callback) {
+  this.detailRow.toggle();
+  if (! this.isDetailLoaded) {
+    this.expand(callback);
+  }
+  this.toggleExpandArrow();
+};
+
+/**
+ * Change the expand/collapse icon accordingly.
+ */
+DetailExpansion.prototype.toggleExpandArrow = function () {
+  if (this.detailRow.is(':hidden')) {
+    this.imgExpansionIcon.removeClass('collapse').addClass('expand').prop('src', RIGHT_ARROW);
+  } else {
+    this.imgExpansionIcon.removeClass('expand').addClass('collapse').prop('src', DOWN_ARROW);
+  }
+}
+
+/**
+ * Toggle case detail
+ *
+ * @param {HTMLElement} originalElement - refer to the base class.
+ * @param {boolean} [isReviewingCase=false] - whether to work on cases under review.
+ * @class
+ */
+function CaseDetailExpansion(originalElement, isReviewingCase) {
+  DetailExpansion.call(this, originalElement);
+  this.isReviewingCase = isReviewingCase === undefined ? false : isReviewingCase;
+}
+
+CaseDetailExpansion.prototype = Object.create(DetailExpansion.prototype);
+
+CaseDetailExpansion.prototype.expand = function (callback) {
+  let self = this
+    , url = '/case/' + this.caseId.toString() +
+    (this.isReviewingCase ? '/review-pane/' : '/readonly-pane/');
+
+  sendHTMLRequest({
+    url: url,
+    container: this.detailRow,
+    callbackAfterFillIn: callback || function () {
+      // As of writing this class, different detail pane spans different
+      // number of columns, which is not set dynamically. This could be a
+      // workaround to fix that. Ideally, it should be set in the backend
+      // somehow.
+      self.detailRow.find('td:first').prop('colspan', self.colspan);
+    }
+  });
+};
+
+function SimpleCaseRunDetailExpansion(originalElement) {
+  DetailExpansion.call(this, originalElement);
+  this.caseRunId = window.parseInt(this.entityRow.find('input[name="case_run"]')[0].value);
+}
+
+SimpleCaseRunDetailExpansion.prototype = Object.create(DetailExpansion.prototype);
+
+SimpleCaseRunDetailExpansion.prototype.expand = function (callback) {
+  sendHTMLRequest({
+    url: '/case/' + this.caseId + '/caserun-simple-pane/',
+    data: {case_run_id: this.caseRunId},
+    container: this.detailRow
+  })
+};
+
+
+/**
+ * Class managing test case run detail expansion.
+ *
+ * @param {HTMLElement} originalElement - refer to base class constructor.
+ * @param {boolean} [showLoading=true] - whether to show the AJAX loading animation.
+ * @class
+ */
+function CaseRunDetailExpansion(originalElement, showLoading) {
+  SimpleCaseRunDetailExpansion.call(this, originalElement);
+  this.showLoadingAnimation = showLoading === undefined ? true : showLoading;
+  // Workaround before renaming caseRow to a general name in base class.
+  this.caseRunRow = this.entityRow;
+  this.caseTextVersion = window.parseInt(this.entityRow.find('input[name="case_text_version"]')[0].value);
+  this.atLastRow = this.detailRow.next().length === 0;
+}
+
+CaseRunDetailExpansion.prototype = Object.create(SimpleCaseRunDetailExpansion.prototype);
+
+CaseRunDetailExpansion.prototype.expand = function (callback) {
+  if (this.showLoadingAnimation) {
+    this.detailRow.html(
+      jQ('<td colspan="14"></td>').html(constructAjaxLoading())
+    );
+  }
+
+  let self = this;
+
+  sendHTMLRequest({
+    url: '/case/' + this.caseId.toString() + '/caserun-detail-pane/',
+    container: this.detailRow[0],
+    callbackAfterFillIn: function () {
+      Nitrate.TestRuns.Details.registerEventHandlersForCaseRunDetail(self);
+    },
+    data: {
+      case_run_id: this.caseRunId,
+      case_text_version: this.caseTextVersion
+    }
+  });
+};
+
+CaseRunDetailExpansion.prototype.showCaseRunDetailAjaxLoading = function () {
+  this.detailRow.html(
+    jQ('<td colspan="14"></td>').html(constructAjaxLoading())
+  );
+};
+
+CaseRunDetailExpansion.prototype.expandCaseRunDetail = function (caseRunRow) {
+  let expansionIcon = caseRunRow.find('img.blind_icon.expand');
+  if (expansionIcon.length > 0) {
+    expansionIcon.trigger('click');
+  }
+};
+
+CaseRunDetailExpansion.prototype.expandNextCaseRunDetail = function () {
+  // The first next is the case run's detail row
+  let nextCaseRunRow = this.detailRow.next();
+  this.expandCaseRunDetail(nextCaseRunRow);
+};
+
+CaseRunDetailExpansion.prototype.collapseCaseRunDetail = function () {
+  if (this.imgExpansionIcon.hasClass('collapse')) {
+    this.imgExpansionIcon.trigger('click');
+  }
+};
+
+
+function PlanCaseRunsExpansion(originalElement) {
+  DetailExpansion.call(this, originalElement);
+  this.caseRunPlanId = window.parseInt(this.entityRow[0].id);
+}
+
+PlanCaseRunsExpansion.prototype = Object.create(DetailExpansion.prototype);
+
+PlanCaseRunsExpansion.prototype.expand = function (callback) {
+  sendHTMLRequest({
+    url: '/case/' + this.caseId.toString() + '/caserun-list-pane/',
+    data: {plan_id: this.caseRunPlanId},
+    container: this.detailRow[0],
+    callbackAfterFillIn: callback,
+  });
+};
+
+
+/**
+ * A simple event handler to toggle a specific test case detail.
+ */
+function caseDetailExpansionHandler() {
+  new CaseDetailExpansion(this).toggle();
+}

--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -7,6 +7,9 @@ window.Nitrate = Nitrate;
 Nitrate.Utils = {};
 const SHORT_STRING_LENGTH = 100;
 
+const RIGHT_ARROW = '/static/images/t1.gif';
+const DOWN_ARROW = '/static/images/t2.gif';
+
 /**
  * Utility function.
  * Set up a function callback for after the page has loaded
@@ -754,7 +757,7 @@ function updateObject(options) {
 /**
  * Create an AJAX loading element.
  *
- * @param {string} id - the new element id.
+ * @param {string} [id] - the new element id.
  * @returns {HTMLElement} the new element.
  */
 function constructAjaxLoading(id) {
@@ -829,26 +832,6 @@ function popupAddAnotherWindow(triggeringLink, parameters) {
   return false;
 }
 
-/**
- * Used for expanding test case in test plan page specifically
- *
- * @param {object} options - options to update the icon of expand/collapse.
- * @param {jQuery} options.caseRowContainer
- *  a jQuery object referring to the container of the test case that is being
- *  expanded to show more information.
- * @param {jQuery} options.expandPaneContainer
- *  a jQuery object referring to the container of the expanded pane showing
- *  test case detail information.
- */
-function toggleExpandArrow(options) {
-  let blindIcon = options.caseRowContainer.find('img.blind_icon');
-  if (options.expandPaneContainer.is(':hidden')) {
-    blindIcon.removeClass('collapse').addClass('expand').prop('src', '/static/images/t1.gif');
-  } else {
-    blindIcon.removeClass('expand').addClass('collapse').prop('src', '/static/images/t2.gif');
-  }
-}
-
 function blinddownAllCases(element) {
   jQ('img.expand').each(function () {
     jQ(this).trigger('click');
@@ -856,7 +839,7 @@ function blinddownAllCases(element) {
   if (element) {
     jQ(element)
       .removeClass('collapse-all').addClass('expand-all')
-      .prop('src', '/static/images/t2.gif');
+      .prop('src', DOWN_ARROW);
   }
 }
 
@@ -868,37 +851,7 @@ function blindupAllCases(element) {
   if (element) {
     jQ(element)
       .removeClass('expand-all').addClass('collapse-all')
-      .prop('src', '/static/images/t1.gif');
-  }
-}
-
-/**
- * Toggle a test case detail pane.
- *
- * @param {object} options - options to toggle test case pane.
- * @param {string|number} options.case_id - the case id.
- * @param {object} options.casePaneContainer - the pane container jQuery object.
- * @param {boolean} options.reviewing - indicate whether to toggle the pane containing reviewing
- *                                      cases.
- * @param {Function} [callback] - a function called when pane content is returned from the server.
- */
-function toggleTestCasePane(options, callback) {
-  let casePaneContainer = options.casePaneContainer;
-
-  // If any of these is invalid, just keep quiet and don't display anything.
-  if (options.case_id === undefined || casePaneContainer === undefined) {
-    return;
-  }
-
-  casePaneContainer.toggle();
-
-  if (casePaneContainer.find('.ajax_loading').length) {
-    let endpoint = options.reviewing ? '/review-pane/' : '/readonly-pane/'
-    sendHTMLRequest({
-      url: '/case/' + options.case_id + endpoint,
-      container: casePaneContainer,
-      callbackAfterFillIn: callback
-    });
+      .prop('src', RIGHT_ARROW);
   }
 }
 

--- a/src/static/js/testcase_actions.js
+++ b/src/static/js/testcase_actions.js
@@ -1,3 +1,6 @@
+/* global caseDetailExpansionHandler, SimpleCaseRunDetailExpansion, PlanCaseRunsExpansion */
+/* global RIGHT_ARROW, DOWN_ARROW */
+
 Nitrate.TestCases = {};
 Nitrate.TestCases.Search = {};
 Nitrate.TestCases.List = {};
@@ -55,20 +58,7 @@ Nitrate.TestCases.SearchResultTableSettings = Object.assign({}, Nitrate.DataTabl
       );
     });
 
-    jQ('.expandable').on('click', function () {
-      let c = jQ(this).parent()[0]; // Container
-      let cContainer = jQ(c).next()[0]; // Content Containers
-      let caseId = parseInt(jQ(c).find(':checkbox').prop('value'));
-
-      toggleTestCasePane({
-        case_id: caseId,
-        casePaneContainer: jQ(cContainer)
-      });
-      toggleExpandArrow({
-        caseRowContainer: jQ(c),
-        expandPaneContainer: jQ(cContainer)
-      });
-    });
+    jQ('.expandable').on('click', caseDetailExpansionHandler);
   },
 
   fnInfoCallback: function (oSettings, iStart, iEnd, iMax, iTotal, sPre) {
@@ -247,28 +237,11 @@ Nitrate.TestCases.Details.on_load = function () {
   });
 
   jQ('.plan_expandable').on('click', function () {
-    let c = jQ(this).parent();
-    toggleCaseRunsByPlan(
-      {
-        'type' : 'case_run_list',
-        'container': c[0],
-        'c_container': c.next()[0],
-        'case_id': c.find('input').first().val(),
-        'case_run_plan_id': c[0].id
-      },
-      function () {
-        jQ('#table_case_runs_by_plan .expandable').on('click', function () {
-          let c = jQ(this).parent(); // Container
-          // FIXME: case_text_version is not used in the backend to show caserun
-          //        information, notes, logs, and comments.
-          toggleSimpleCaseRunPane({
-            caserunRowContainer: c,
-            expandPaneContainer: c.next(),
-            caseId: c.find('input[name="case"]')[0].value,
-            caserunId: c.find('input[name="case_run"]')[0].value
-          });
-        });
+    new PlanCaseRunsExpansion(this).toggle(function () {
+      jQ('#table_case_runs_by_plan .expandable').on('click', function () {
+        new SimpleCaseRunDetailExpansion(this).toggle();
       });
+    });
   });
 
   jQ('#btn_edit,#btn_clone').on('click', function () {
@@ -408,27 +381,6 @@ Nitrate.TestCases.Clone.on_load = function () {
   });
 
 };
-
-
-/*
- * Toggle simple caserun pane in Case Runs tab in case page.
- */
-function toggleSimpleCaseRunPane(options) {
-  options.expandPaneContainer.toggle();
-
-  if (options.caserunRowContainer.next().find('.ajax_loading').length) {
-    sendHTMLRequest({
-      url: '/case/' + options.caseId + '/caserun-simple-pane/',
-      data: {case_run_id: options.caserunId},
-      container: options.expandPaneContainer
-    })
-  }
-
-  toggleExpandArrow({
-    caseRowContainer: options.caserunRowContainer,
-    expandPaneContainer: options.expandPaneContainer
-  });
-}
 
 /**
  * A function bound to AJAX request success event to add or remove issue to and from a case. It
@@ -597,8 +549,8 @@ function toggleCaseRunsByPlan(params, callback) {
 
   let blindIcon = container.find('img').first();
   if (contentContainer.is(':hidden')) {
-    blindIcon.removeClass('collapse').addClass('expand').prop('src', '/static/images/t1.gif');
+    blindIcon.removeClass('collapse').addClass('expand').prop('src', RIGHT_ARROW);
   } else {
-    blindIcon.removeClass('expand').addClass('collapse').prop('src', '/static/images/t2.gif');
+    blindIcon.removeClass('expand').addClass('collapse').prop('src', DOWN_ARROW);
   }
 }

--- a/src/static/js/testplan_actions.js
+++ b/src/static/js/testplan_actions.js
@@ -1,3 +1,6 @@
+/* global CaseDetailExpansion */
+/* global RIGHT_ARROW, DOWN_ARROW */
+
 Nitrate.TestPlans = {};
 Nitrate.TestPlans.Create = {};
 Nitrate.TestPlans.List = {};
@@ -996,23 +999,15 @@ function bindEventsOnLoadedCases(options) {
     // Expand/collapse case details pane
     jQ(container).parent().find('.expandable.js-just-loaded').on('click', function () {
       let btn = this
-        , title = jQ(this).parent() // Container
-        , content = jQ(this).parent().next() // Content Containers
+        , caseDetailRow = jQ(this).parent().next() // Content Containers
         , inReviewingCasesTab = form.type.value === 'review_case';
 
-      toggleTestCasePane(
-        {
-          case_id: title.prop('id'),
-          casePaneContainer: content,
-          reviewing: inReviewingCasesTab
-        },
-        inReviewingCasesTab ? reviewCaseContentCallback(jQ(btn), content) : function () {}
+      new CaseDetailExpansion(this, inReviewingCasesTab).toggle(
+        inReviewingCasesTab ? reviewCaseContentCallback(jQ(btn), caseDetailRow) : function () {}
       );
 
-      toggleExpandArrow({caseRowContainer: title, expandPaneContainer: content});
-
-      let iconFile = areAllCasesCollapsed(inReviewingCasesTab, container) ? 't1.gif' : 't2.gif';
-      jQ(container).find('img.js-expand-collapse-cases').prop('src', '/static/images/' + iconFile);
+      let iconFile = areAllCasesCollapsed(inReviewingCasesTab, container) ? RIGHT_ARROW : DOWN_ARROW;
+      jQ(container).find('img.js-expand-collapse-cases').prop('src', iconFile);
     });
 
     /*
@@ -1117,28 +1112,6 @@ function changeCaseOrder2(parameters, callback) {
     traditional: true,
     success: callback
   });
-}
-
-// TODO: here
-function toggleAllCases(element) {
-  // FIXME: what does this if do?
-  //If and only if both case length is 0, remove the lock.
-  if (jQ('div[id^="id_loading_"].normal_cases').length === 0 && jQ('div[id^="id_loading_"].review_cases').length === 0){
-    jQ(element).removeClass('locked');
-  }
-
-  if (jQ(element).is('.locked')) {
-    return false;
-  } else {
-    jQ(element).addClass('locked');
-    if (jQ(element).is('.collapse-all')) {
-      element.title = 'Collapse all cases';
-      blinddownAllCases(element);
-    } else {
-      element.title = 'Expand all cases';
-      blindupAllCases(element);
-    }
-  }
 }
 
 /**
@@ -1322,19 +1295,12 @@ function constructPlanDetailsCasesZone(container, planId, parameters) {
       let allCasesExpanded = false;
 
       jQ(casesTable).find('img.js-expand-collapse-cases').on('click', function () {
-        // let iconFile = allCasesExpanded ? 't1.gif' : 't2.gif';
-        // jQ(this).prop('src', '/static/images/' + iconFile);
-
         jQ(casesTable).find('img.js-expand-collapse-case').each(function () {
           let caseTr = jQ(this).parents('tr')
             , caseDetailsTr = caseTr.next();
 
           if (caseDetailsTr.is(allCasesExpanded ? ':visible' : ':hidden')) {
             jQ(this).trigger('click');
-            toggleExpandArrow({
-              caseRowContainer: caseTr,
-              expandPaneContainer: caseDetailsTr
-            });
           }
         });
 

--- a/src/templates/case/all.html
+++ b/src/templates/case/all.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="{% static "js/lib/jquery.dataTables.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript">
 Nitrate.TestCases.Search.ActionUrls = {
   printableCasesUrl: '{% url "cases-printable" %}',

--- a/src/templates/case/get.html
+++ b/src/templates/case/get.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="{% static "js/lib/dataTables.numHTML.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/nitrate.attachments.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript">
 Nitrate.Utils.after_page_load(Nitrate.TestCases.Details.on_load);
 Nitrate.Utils.after_page_load(Nitrate.Attachments.on_load);

--- a/src/templates/case/get_details_case_case_run.html
+++ b/src/templates/case/get_details_case_case_run.html
@@ -1,4 +1,4 @@
-<td colspan='12'>
+<td colspan='13'>
 	<h4>Notes:</h4>
 	<p>{{ test_caserun.notes|urlize|linebreaksbr }}</p>
 	<h4>Comments:</h4>

--- a/src/templates/plan/choose_testrun.html
+++ b/src/templates/plan/choose_testrun.html
@@ -9,6 +9,7 @@
 
 {% block custom_javascript %}
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript">
 Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 </script>
@@ -95,7 +96,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 					<tr id="row_{{ forloop.counter }}" class="{% cycle 'odd' 'even' %} selection_row js-one-case">
 						<td>
 							<a id="blind_link_{{ forloop.counter }}" class="blind_link js-toggle-button" href="javascript:void(0);" data-param="{{ forloop.counter }}">
-								<img id="blind_icon_{{ forloop.counter }}" src="{% static "images/t1.gif" %}" border="0" alt="">
+								<img id="blind_icon_{{ forloop.counter }}" class="blind_icon" src="{% static "images/t1.gif" %}" border="0" alt="">
 							</a>
 						</td>
 						<td>
@@ -114,7 +115,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.ChooseRuns.on_load);
 						<td>{{ test_case.sortkey }}</td>
 						<td></td>
 					</tr>
-					<tr class="hide"  id="hidenRow_{{ forloop.counter }}" class="Detailform border-1" style="display: none;">
+					<tr id="hidenRow_{{ forloop.counter }}" class="Detailform border-1 hide" style="display: none;">
 						<td colspan="9" id="id_case_text_{{ forloop.counter }}">
 							<div class="ajax_loading"></div>
 						</td>

--- a/src/templates/plan/get.html
+++ b/src/templates/plan/get.html
@@ -17,6 +17,7 @@
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/nitrate.attachments.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript" src="/jsi18n/"></script>
 <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/core.js" %}"></script>

--- a/src/templates/run/assign_case.html
+++ b/src/templates/run/assign_case.html
@@ -11,6 +11,7 @@
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript">
 Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 </script>
@@ -92,7 +93,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 						</td>
 						<td>
 							<a id="blind_link_{{ forloop.counter }}" class="blind_link js-toggle-button" data-param="{{ forloop.counter }}" href="javascript:void(0);">
-								<img id="blind_icon_{{ forloop.counter }}" src="{% static "images/t1.gif" %}" border="0" alt="">
+								<img class="blind_icon" src="{% static "images/t1.gif" %}" border="0" alt="">
 							</a>
 						</td>
 						<td>
@@ -109,7 +110,7 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.AssignCase.on_load);
 						<td>{{ test_case.priority__value }}</td>
 					</tr>
 					<tr class="hide"  id="hidenRow_{{ forloop.counter }}" class="Detailform border-1" style="display: none;">
-						<td colspan="9" id="id_case_text_{{ forloop.counter }}">
+						<td colspan="8" id="id_case_text_{{ forloop.counter }}">
 							<div class="ajax_loading"></div>
 						</td>
 					</tr>

--- a/src/templates/run/clone.html
+++ b/src/templates/run/clone.html
@@ -9,6 +9,7 @@
 
 {% block custom_javascript %}
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 <script type="text/javascript">
@@ -159,20 +160,16 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 						{% for case_run in cases_run.all %}
 						<tr class="{% cycle 'odd' 'even' %} js-one-case" id="row_{{ forloop.counter }}">
 							<td>
-								<a id="blind_link_{{ forloop.counter }}" class="blind_link" href="javascript:toggleTestCaseContents('{{ forloop.counter }}')">
-									<img id="blind_icon_{{ forloop.counter }}" src="{% static "images/t1.gif" %}" border="0" alt="">
+								<a id="blind_link_{{ forloop.counter }}" class="blind_link" href="javascript:void(0)">
+									<img id="blind_icon_{{ forloop.counter }}" class="blind_icon" src="{% static "images/t1.gif" %}" border="0" alt="">
 								</a>
 							</td>
 							<td>
 								<a href="{% url "case-get" case_run.case_id %}">{{ case_run.case_id }}</a>
 								<input type="hidden" name="case" value="{{ case_run.case_id }}">
-															<input type="hidden" name="case_run_id" value="{{ case_run.case_run_id }}">
+								<input type="hidden" name="case_run_id" value="{{ case_run.case_run_id }}">
 							</td>
-							<td>
-								<a id="link_{{ forloop.counter }}" class="blind_title_link" href="javascript:toggleTestCaseContents('{{ forloop.counter }}')">
-									{{ case_run.case.summary }}
-								</a>
-							</td>
+							<td>{{ case_run.case.summary }}</td>
 							<td>{{ case_run.case.author.email }}</td>
 							<td>{{ case_run.case.create_date }}</td>
 							<td>{{ case_run.case.case_status }}</td>
@@ -185,9 +182,9 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 								</a>
 							</td>
 						</tr>
-						<tr class="hide" id="hidenRow_{{ forloop.counter }}" class="Detailform border-1" style="display: none;">
-							<td id="id_case_text_{{ forloop.counter }}" style="display: none;">
-								<div class="ajax_loading">
+						<tr id="hidenRow_{{ forloop.counter }}" class="Detailform border-1 hide" style="display: none;">
+							<td id="id_case_text_{{ forloop.counter }}" colspan="10">
+								<div class="ajax_loading"></div>
 							</td>
 						</tr>
 						{% endfor %}
@@ -196,4 +193,5 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.Clone.on_load);
 			</div>
 		</div>
 	</form>
-	{% endblock %}
+</div>
+{% endblock %}

--- a/src/templates/run/get.html
+++ b/src/templates/run/get.html
@@ -8,6 +8,7 @@
 <script type="text/javascript" src="{% static "js/lib/jquery.tablednd.js" %}"></script>
 <script type="text/javascript" src="{% static "js/comment.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript">
 {# Define the case_run_status array for all of case run status #}
 Nitrate.TestRuns.CaseRunStatus = new Array();

--- a/src/templates/run/new.html
+++ b/src/templates/run/new.html
@@ -15,6 +15,7 @@
 <script type="text/javascript" src="{% static "js/testrun_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
 <script type="text/javascript" src="{% static "js/testplan_actions.js" %}"></script>
+<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 <script type="text/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 
 <script type="text/javascript">
@@ -145,7 +146,8 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 			<table id="testcases" class="list" cellpadding="0" cellspacing="0" border="0" >
 				<thead>
 					<tr>
-						<th  class="widthID" align="left" width="4%" >ID</th>
+						<th align="left" width="2%"></th>
+						<th class="widthID" align="left" width="4%" >ID</th>
 						<th align="left" width="26%" >Test Case Summary</th>
 						<th align="left" width="20%">Author</th>
 						<th align="left" width="20%">Created Date</th>
@@ -157,7 +159,12 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 				<tbody>
 					{% for test_case in test_cases %}
 					<tr class="{% cycle 'odd' 'even' %}" id="row_{{ forloop.counter }}" >
-						<td >
+						<td>
+							<a id="blind_link_{{ forloop.counter }}" class="blind_link" href="javascript:void(0)">
+								<img id="blind_icon_{{ forloop.counter }}" class="blind_icon" src="{% static "images/t1.gif" %}" border="0" alt="">
+							</a>
+						</td>
+						<td>
 							<a href="/case/{{ test_case.case_id }}/">{{ test_case.case_id }}</a>
 							{% if test_case.case_status.name == 'CONFIRMED' %}
 							<input type="hidden" name="case" value="{{ test_case.case_id }}">
@@ -172,9 +179,14 @@ Nitrate.Utils.after_page_load(Nitrate.TestRuns.New.on_load);
 						<td>{{ test_case.author.email }}</td>
 						<td>{{ test_case.create_date }}</td>
 						<td>{{ test_case.category }}</td>
-						<td >{{ test_case.priority }}</td>
+						<td>{{ test_case.priority }}</td>
 						<td>
 							<a class="deletelink js-remove-case" data-params='["row_{{ forloop.counter }}", {{ test_case.estimated_time|timedelta2seconds }}]'>Remove</a>
+						</td>
+					</tr>
+					<tr id="hidenRow_{{ forloop.counter }}" class="Detailform border-1 hide" style="display: none;">
+						<td id="ajax_loading_{{ forloop.counter }}" colspan="8">
+							<div class="ajax_loading"></div>
 						</td>
 					</tr>
 					{% endfor %}

--- a/src/templates/search/results.html
+++ b/src/templates/search/results.html
@@ -42,6 +42,7 @@
 	{% elif search_target == "case" %}
 
 	<script type="text/javascript" src="{% static "js/testcase_actions.js" %}"></script>
+	<script type="text/javascript" src="{% static "js/nitrate.toggledetail.js" %}"></script>
 	<script type="text/javascript">
 	  Nitrate.TestCases.Search.ActionUrls = {
 		printableCasesUrl: '{% url "cases-printable" %}',

--- a/src/tests/testruns/test_views.py
+++ b/src/tests/testruns/test_views.py
@@ -202,15 +202,9 @@ class CloneRunBaseTest(BaseCaseRun):
 
         for forloop_counter, case_run in enumerate((self.case_run_1, self.case_run_2), 1):
             self.assertContains(
-                response,
-                '<a href="/case/{0}/">{0}</a>'.format(case_run.case.pk),
-                html=True)
-            self.assertContains(
-                response,
-                '<a id="link_{0}" class="blind_title_link" '
-                'href="javascript:toggleTestCaseContents(\'{0}\')">{1}</a>'.format(
-                    forloop_counter, case_run.case.summary),
-                html=True)
+                response, '<a href="/case/{0}/">{0}</a>'.format(case_run.case.pk), html=True
+            )
+            self.assertContains(response, f'<td>{case_run.case.summary}</td>', html=True)
 
 
 class TestStartCloneRunFromRunPage(CloneRunBaseTest):


### PR DESCRIPTION
Detail expansion involves expanding case detail, expanding case run
detail and expanding a plan's case runs under a case. Lots of duplicate
code handles that various detail expansions. All of them have similar
logic and almost same HTML structure rendered from templates. Years
later, such situation makes it difficult to maintain those code.

This patch removes those duplicate code by organizing them into
dedicated classes and unify all the things in a well-structured
JavaScript code base and templates.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>