### PR TITLE
Fetch all history in order to run git-describe

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -11,17 +11,24 @@ jobs:
     name: Build the RPM
     runs-on: ubuntu-latest
     steps:
+    - run: sudo apt-get install git
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - run: echo "${{ secrets.COPR_CONF }}" > copr_conf
+    - run: |
+        IFS='-' read version commits last_commit <<< $(git describe)
+        echo "NITRATE_VERSION=$(cat VERSION.txt)" >> $GITHUB_ENV
+        echo "NITRATE_COMMITS=${commits}" >> $GITHUB_ENV
+        echo "NITRATE_LAST_COMMIT=${last_commit}" >> $GITHUB_ENV
     - name: Build the package
       run: |
         docker run --name package-build -v $(pwd):/code:Z registry.fedoraproject.org/fedora:33 /bin/bash -c "
           set -ex
           dnf install -y git make rpmdevtools copr-cli rpm-build python3
           cd /code
-          IFS='-' read version commits last_commit <<< \$(git describe)
           rpmdev-bumpspec \
-            -n \"\$(cat VERSION.txt)-\$commits.\$last_commit%{?dist}\" \
+            -n '${NITRATE_VERSION}-${NITRATE_COMMITS}.${NITRATE_LAST_COMMIT}%{?dist}' \
             -c 'Rebuilt for latest' \
             -u 'autobuild <autobuild@localhost>' \
             -D \
@@ -35,10 +42,10 @@ jobs:
     needs: copr-build
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt-get install make
-      - uses: actions/checkout@v2
-      - run: CONTAINER=docker make latest-image
-      - name: Publish image
-        run: |
-          QUAY_USER=${{ secrets.quay_username }} QUAY_PASSWORD=${{ secrets.quay_token }} \
-          CONTAINER=docker make publish-image
+    - run: sudo apt-get install make
+    - uses: actions/checkout@v2
+    - run: CONTAINER=docker make latest-image
+    - name: Publish image
+      run: |
+        QUAY_USER=${{ secrets.quay_username }} QUAY_PASSWORD=${{ secrets.quay_token }} \
+        CONTAINER=docker make publish-image


### PR DESCRIPTION
By default, actions/checkout does not fetch tags, then git-describe
fails to output the result.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>