### PR TITLE
Use dummy email backend for local run inside container

### DIFF
--- a/contrib/compose/web_custom_conf.py
+++ b/contrib/compose/web_custom_conf.py
@@ -2,3 +2,5 @@ ASYNC_TASK = 'CELERY'
 CELERY_BROKER_URL = 'amqp://messagebus:5672/myvhost'
 # Celery worker settings
 CELERY_TASK_IGNORE_RESULT = True
+
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'


### PR DESCRIPTION
When run locally inside container, the email backend is not
pre-configured and ready-for-use. This causes Nitrate raises 500 error
when sending email notification. Using dummy email backend makes things
easy and user is able to change it to a real email backend along with
setting other EMAIL_* settings.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>