### PR TITLE
Fix mailto task argument user type

### DIFF
--- a/src/tcms/core/ajax.py
+++ b/src/tcms/core/ajax.py
@@ -582,7 +582,7 @@ class PatchTestCaseRunsView(ModelPatchBaseView):
     def _sendmail(self, objects) -> None:
         mail_context = TestCaseRun.mail_scene(objects=objects, field=self.target_field)
         if mail_context:
-            mail_context["context"]["user"] = self.request.user
+            mail_context["context"]["user"] = self.request.user.username
             mailto(**mail_context)
 
     def _update_case_run_status(self):


### PR DESCRIPTION
The type User cannot be serialized to JSON when schedule the mailto
asynchronous task. The change works for rendering corresponding template
that just renders the user's name.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>