### PR TITLE
Show components and tags in order in case run detailed info

### DIFF
--- a/src/tcms/testcases/views.py
+++ b/src/tcms/testcases/views.py
@@ -768,7 +768,7 @@ class TestCaseCaseRunDetailPanelView(
         this_cls = TestCaseCaseRunDetailPanelView
         data = super(this_cls, self).get_context_data(**kwargs)
 
-        case = get_object_or_404(TestCase.objects.only("pk"), pk=self.case_id)
+        case: TestCase = get_object_or_404(TestCase.objects.only("pk"), pk=self.case_id)
         case_run = get_object_or_404(TestCaseRun, pk=self.case_run_id, case=case)
 
         # Data of TestCase
@@ -798,6 +798,8 @@ class TestCaseCaseRunDetailPanelView(
                 "test_case_run_status": caserun_status,
                 "grouped_case_issues": issues,
                 "has_issue_trackers": has_issue_trackers,
+                "components": case.component.order_by("name"),
+                "tags": case.tag.order_by("name"),
             }
         )
 

--- a/src/templates/case/get_details_case_run.html
+++ b/src/templates/case/get_details_case_run.html
@@ -197,7 +197,7 @@
 						<td>
 							<h4 class="borderB">Component</h4>
 							<ul class="ul-no-format">
-								{% for component in test_case.component.all %}
+								{% for component in components %}
 								<li>{{ component.name }}</li>
 								{% empty %}
 								<li class="grey">No component found</li>
@@ -208,7 +208,7 @@
 						<td>
 							<h4 class="borderB">Tag:</h4>
 							<ul class="ul-no-format">
-								{% for tag in test_case.tag.all %}
+								{% for tag in tags %}
 								<li>{{ tag }}</li>
 								{% empty %}
 								<li class="grey">No tag found</li>

--- a/src/tests/testcases/test_views.py
+++ b/src/tests/testcases/test_views.py
@@ -2488,7 +2488,7 @@ class TestCaseCaseRunDetailPanelView(BaseCaseRun):
             f"{self.attachment_screenshort.file_name}"
             f"</a></li>"
             f"</ul>",
-            '<ul class="ul-no-format"><li>db</li><li>web</li><li>dist</li></ul>',
+            '<ul class="ul-no-format"><li>db</li><li>dist</li><li>web</li></ul>',
             '<ul class="ul-no-format"><li>python</li><li>webapp</li></ul>',
         ]
 


### PR DESCRIPTION
Order the components and tags by name explicitly. Without this explicit
order, PostgreSQL returns the SELECT query in an unpredictable order.
The corresponding test fails due to this problem.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>