### PR TITLE
Pass value to middleware get_response argument (#942)

### DIFF
--- a/src/tests/xmlrpc/test_auth.py
+++ b/src/tests/xmlrpc/test_auth.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from unittest.mock import Mock
+
 from django.contrib.auth.models import User
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
@@ -21,7 +23,7 @@ class TestLoginWithModelBackend(TestCase):
         request = RequestFactory().post("/xmlrpc/")
         request.user = self.tester
         # Ensure request.session is set
-        SessionMiddleware().process_request(request)
+        SessionMiddleware(Mock()).process_request(request)
         session_key = auth.login(request, {"username": "tester", "password": "123"})
 
         self.assertTrue(request.user.is_authenticated)


### PR DESCRIPTION
Fix RemovedInDjango40Warning: Passing None for the middleware
get_response argument is deprecated.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>