### PR TITLE
Refactor two tests to remove warning (#991)

### DIFF
--- a/src/tcms/testplans/models.py
+++ b/src/tcms/testplans/models.py
@@ -539,7 +539,7 @@ class TestPlan(TCMSActionModel):
             result.remove(self.pk)
             return result
 
-    def get_ancestors(self):
+    def get_ancestors(self) -> QuerySet:
         ancestor_ids = self.get_ancestor_ids()
         return TestPlan.objects.filter(pk__in=ancestor_ids)
 

--- a/src/tests/testplans/test_models.py
+++ b/src/tests/testplans/test_models.py
@@ -256,11 +256,18 @@ class TestPlanTreeView(BasePlanCase):
 
     def test_get_ancestors(self):
         ancestor_ids = [self.plan.pk, self.plan_2.pk, self.plan_3.pk]
-        expected = [
-            repr(item) for item in TestPlan.objects.filter(pk__in=ancestor_ids).order_by("pk")
-        ]
-        plan: TestPlan = TestPlan.objects.get(pk=self.plan_4.pk)
-        self.assertQuerysetEqual(plan.get_ancestors().order_by("pk"), expected)
+        expected = list(
+            TestPlan.objects.filter(pk__in=ancestor_ids).values_list("pk", flat=True).order_by("pk")
+        )
+        self.assertListEqual(
+            list(
+                TestPlan.objects.get(pk=self.plan_4.pk)
+                .get_ancestors()
+                .values_list("pk", flat=True)
+                .order_by("pk")
+            ),
+            expected,
+        )
 
     def test_get_descendant_ids(self):
         expected = [self.plan_4.pk, self.plan_5.pk, self.plan_6.pk, self.plan_7.pk]
@@ -274,11 +281,20 @@ class TestPlanTreeView(BasePlanCase):
             self.plan_6.pk,
             self.plan_7.pk,
         ]
-        expected = [
-            repr(item) for item in TestPlan.objects.filter(pk__in=descendant_ids).order_by("pk")
-        ]
-        plan: TestPlan = TestPlan.objects.get(pk=self.plan_3.pk)
-        self.assertQuerysetEqual(plan.get_descendants().order_by("pk"), expected)
+        expected = list(
+            TestPlan.objects.get(pk=self.plan_3.pk)
+            .get_descendants()
+            .values_list("pk", flat=True)
+            .order_by("pk")
+        )
+        self.assertListEqual(
+            list(
+                TestPlan.objects.filter(pk__in=descendant_ids)
+                .values_list("pk", flat=True)
+                .order_by("pk")
+            ),
+            expected,
+        )
 
     def test_get_direct_descendants(self):
         test_data = [


### PR DESCRIPTION
This removes RemovedInDjango41Warning: In Django 4.1, repr() will not be
called automatically on a queryset when compared to string values. Set
an explicit 'transform' to silence this warning.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>