### PR TITLE
Show plans in order by pk when clone

### DIFF
--- a/src/tcms/testplans/views.py
+++ b/src/tcms/testplans/views.py
@@ -495,7 +495,7 @@ def clone(request, template_name="plan/clone.html"):
             "At least one plan is required by clone function.",
         )
 
-    tps = TestPlan.objects.filter(pk__in=req_data.getlist("plan"))
+    tps = TestPlan.objects.filter(pk__in=req_data.getlist("plan")).order_by("-pk")
 
     if not tps:
         return prompt.info(

--- a/src/tests/testplans/test_views.py
+++ b/src/tests/testplans/test_views.py
@@ -457,16 +457,18 @@ class TestCloneView(BasePlanCase):
         )
 
         plans_li = [
-            """<li>
-    <span class="lab-50">{}</span>
-    <span class="lab-100">{}</span>
-    <span>
-        <a href="" title="{} ({})">{}</a>
-    </span>
-</li>""".format(
+            """\
+            <li>
+                <span class="lab-50">{}</span>
+                <span class="lab-100">{}</span>
+                <span>
+                    <a href="" title="{} ({})">{}</a>
+                </span>
+            </li>
+            """.format(
                 plan.pk, plan.type, plan.name, plan.author.email, plan.name
             )
-            for plan in (self.plan, self.another_plan)
+            for plan in (self.another_plan, self.plan)
         ]
 
         self.assertContains(


### PR DESCRIPTION
When running PostgreSQL, the reutrn dataset is not guaranteed in the
order of primary key. This change ensures the plans are shown in order
and it also makes it easier to write tests.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>