### PR TITLE
Missing path in the python.install in rtd config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,5 +15,6 @@ python:
    install:
    - requirements: docs/requirements.txt
    - method: pip
+     path: .
      extra_requirements:
      - docs


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>