### PR TITLE
JS: call a function to get the AJAX CSRF token (#1031)

### DIFF
--- a/src/static/js/tcms_actions.js
+++ b/src/static/js/tcms_actions.js
@@ -115,6 +115,18 @@ Nitrate.Utils.changeOrderSortKey = function (changeOrderRequestFunc, curSortKey)
 }
 
 /**
+ * Return the CSRF token generated for POST HTTP request.
+ *
+ * This requires the CSRF token is generated in the DOM.
+ *
+ * @return {string} the CSRF token.
+ */
+function getAjaxCsrfToken() {
+  return document.getElementById('ajaxCsrfToken')
+    .querySelector('[name=csrfmiddlewaretoken]').value;
+}
+
+/**
  * Simple wrapper of jQuery.ajax to add header for CSRF.
  *
  * @param {string} url - a url passed to url argument of jQuery $.ajax
@@ -124,7 +136,7 @@ function $ajax(url, options) {
   options = Object.assign({}, options, {
     beforeSend: function (xhr, settings) {
       if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type) && !this.crossDomain) {
-        xhr.setRequestHeader('X-CSRFToken', globalCsrfToken);
+        xhr.setRequestHeader('X-CSRFToken', getAjaxCsrfToken());
       }
     },
   });
@@ -682,7 +694,7 @@ function postToURL(path, params, method) {
     let csrfTokenHidden = document.createElement('input');
     csrfTokenHidden.setAttribute('type', 'hidden');
     csrfTokenHidden.setAttribute('name', 'csrfmiddlewaretoken');
-    csrfTokenHidden.setAttribute('value', globalCsrfToken);
+    csrfTokenHidden.setAttribute('value', getAjaxCsrfToken());
     form.appendChild(csrfTokenHidden);
   }
 

--- a/src/templates/csrf.html
+++ b/src/templates/csrf.html
@@ -1,4 +1,0 @@
-{% csrf_token %}
-<script type="text/javascript">
-	const globalCsrfToken = jQ('[name=csrfmiddlewaretoken]').val();
-</script>

--- a/src/templates/tcms_base.html
+++ b/src/templates/tcms_base.html
@@ -40,7 +40,6 @@
 	{% block extra_head %}{% endblock %}
 </head>
 <body id="body">
-	{% include "csrf.html" %}
 	<div id="header">
 		<div class="logo">
 		<a href="{% url "nitrate-index" %}"><img src="{% static "images/logo_shipshape_1.png" %}" alt="logo" /></a>
@@ -93,5 +92,6 @@
 			});
 		});
 	</script>
+	<div id="ajaxCsrfToken">{% csrf_token %}</div>
 </body>
 </html>


### PR DESCRIPTION
This change also removes the need of jQuery.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

closes: #1031 