### PR TITLE
Allow to specify test module for tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ extras =
     bugzilla
     krbauth
     tests
-commands = py.test -s src/tests/ {posargs}
+commands = py.test -s {posargs:"src/tests/"}
 
 [docker:testdb_mysql]
 image = mysql:8.0.22


### PR DESCRIPTION
src/tests/ is not hardcoded in testenv.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>