### PR TITLE
Use md5 password hasher for tests

### DIFF
--- a/src/tcms/settings/test.py
+++ b/src/tcms/settings/test.py
@@ -30,6 +30,9 @@ if DB_ENGINE == "mysql":
 elif DB_ENGINE == "pgsql":
     DATABASES["default"]["TEST"] = {"CHARSET": "utf8"}
 
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
 
 SECRET_KEY = "key-for-test"  # nosec
 


### PR DESCRIPTION
According to /topics/testing/overview/#password-hashing, this is a
faster way to run tests and actually it is, really!

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>