### PR TITLE
Add new setting DEFAULT_AUTO_FIELD

### DIFF
--- a/src/tcms/settings/common.py
+++ b/src/tcms/settings/common.py
@@ -54,6 +54,8 @@ DATABASES = {
     # }
 }
 
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["*"]


### PR DESCRIPTION
This is introduced in Django 3.2 and is required in settings or warnings
will be printed as:

testruns.TestRunTag: (models.W042) Auto-created primary key used when
not defining a primary key type, by default
'django.db.models.AutoField'.
    HINT: Configure the DEFAULT_AUTO_FIELD setting or the
    AppConfig.default_auto_field attribute to point to a subclass of
    AutoField, e.g. 'django.db.models.BigAutoField'.

The BugAutoField will be applied to a new generated database. By a quick
testing, no need to update the existing database, no migration there.
Hopefully, everything works well as normal with this change.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>