### PR TITLE
Bugfix: Add django social app

### DIFF
--- a/src/tcms/urls.py
+++ b/src/tcms/urls.py
@@ -39,6 +39,10 @@ urlpatterns = [
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
 ]
 
+# Python Social Core / Django Social Auth
+if "SOCIAL" in settings.ENABLED_AUTH_BACKENDS:
+    urlpatterns += [path("", include("social_django.urls", namespace="social"))]
+
 # Debug zone
 
 if settings.DEBUG:


### PR DESCRIPTION
If 'SOCIAL' is an enabled AUTH Backend, the
social_django.urls must be added to the url_patterns

Fixes #1095 / Closes #1095