### PR TITLE
refactor(management): remove unused Product model methods

### DIFF
--- a/src/tcms/management/models.py
+++ b/src/tcms/management/models.py
@@ -88,35 +88,6 @@ class Product(TCMSActionModel):
         self.version.get_or_create(value="unspecified")
         self.build.get_or_create(name="unspecified")
 
-    def get_version_choices(self, allow_blank):
-        # Generate a list of (id, string) pairs suitable
-        # for a ChoiceField's "choices":
-        return get_as_choices(self.version.all(), allow_blank)
-
-    def get_build_choices(self, allow_blank, only_active):
-        # Generate a list of (id, string) pairs suitable
-        # for a ChoiceField's "choices"
-        #
-        # @only_active: restrict to only show builds flagged as "active"
-        q = self.build
-        if only_active:
-            q = q.filter(is_active=True)
-        return get_as_choices(q.all(), allow_blank)
-
-    def get_environment_choices(self, allow_blank):
-        # Generate a list of (id, string) pairs suitable
-        # for a ChoiceField's "choices":
-        return get_as_choices(self.environments.all(), allow_blank)
-
-    @classmethod
-    def get_choices(cls, allow_blank):
-        # Generate a list of (id, string) pairs suitable
-        # for a ChoiceField's "choices":
-        return get_as_choices(cls.objects.order_by("name").all(), allow_blank)
-
-    def as_choice(self):
-        return (self.id, self.name)
-
 
 class Priority(TCMSActionModel):
     id = models.AutoField(primary_key=True)


### PR DESCRIPTION
## Summary

Closes #951.

Removes the five `Product` model methods listed in the issue. All are unused in both Python and HTML templates (verified by repo-wide grep).

## Changes

`src/tcms/management/models.py` - drops from `Product`:

- `get_version_choices(allow_blank)`
- `get_build_choices(allow_blank, only_active)`
- `get_environment_choices(allow_blank)`
- `get_choices(allow_blank)` (classmethod)
- `as_choice()`

Net -29 lines.

## Verification

```
$ grep -rn "get_version_choices\|get_build_choices\|get_environment_choices" \
      --include="*.py" --include="*.html"
src/tcms/management/models.py:  # removed

$ grep -rn "\.get_choices\|Product\.as_choice" \
      --include="*.py" --include="*.html"
src/tcms/management/models.py:  # removed
```

- The three `get_*_choices` instance methods had zero external callers.
- `get_choices` classmethod had zero external callers.
- `Product.as_choice()` was only reached through the removed `get_choices` classmethod. The `as_choice()` methods on `Version`, `TestBuild`, and `TestEnvironment` stay because `get_as_choices` iterates their querysets from other live call sites.

Module-level helpers `get_as_choices` and `get_all_choices` are out of scope for this issue and untouched.

## Testing

`python3 -c "import ast; ast.parse(...)"` - clean. No behavior change in callers (there are none).